### PR TITLE
Support Mac Catalyst

### DIFF
--- a/ios/RNCNetInfo.m
+++ b/ios/RNCNetInfo.m
@@ -12,7 +12,8 @@
 #include <arpa/inet.h>
 
 #if !TARGET_OS_TV
-@import CoreTelephony;
+#import<CoreTelephony/CTCarrier.h>
+#import<CoreTelephony/CTTelephonyNetworkInfo.h>
 #endif
 @import SystemConfiguration.CaptiveNetwork;
 

--- a/ios/RNCNetInfo.m
+++ b/ios/RNCNetInfo.m
@@ -12,8 +12,8 @@
 #include <arpa/inet.h>
 
 #if !TARGET_OS_TV
-#import<CoreTelephony/CTCarrier.h>
-#import<CoreTelephony/CTTelephonyNetworkInfo.h>
+#import <CoreTelephony/CTCarrier.h>
+#import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #endif
 @import SystemConfiguration.CaptiveNetwork;
 


### PR DESCRIPTION
The way that telephony was imported broke builds for catalyst, this imports the 2/4 specific files that are used in CoreTelephony.