### PR TITLE
Use androidx.core:core:1.3.2 instead of dynamic 1.+ version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -60,7 +60,7 @@ dependencies {
   if (supportLibVersion && androidXVersion == null && androidXCore == null) {
     implementation "com.android.support:appcompat-v7:$supportLibVersion"
   } else {
-    def defaultAndroidXVersion = "1.+"
+    def defaultAndroidXVersion = "1.3.2"
     if (androidXCore == null) {
       androidXCore = androidXVersion == null ? defaultAndroidXVersion : androidXVersion
     }


### PR DESCRIPTION
# Overview
  Hi 👋
  Here is a small proposal of fixing a version of `androidx.core:core` artifact used in this project.

  Currently the `com.reactnativecommunity:netinfo:5.9.6` artifact is published with dynamic version for the `androidx.core:core` artifact.
  This causes silently putting the latest, less stable alpha versions of `androidx.core:core` to be pulled transitively, unless this is suppressed or overriden everywhere in the project.

  Example output of Gradle dependencies resolution:
  ```
  |    +--- com.reactnativecommunity:netinfo:5.9.6
  |    |    \--- androidx.core:core:1.+ -> 1.5.0-alpha04 (*)
  ```

 It can be definitely fixed from the consumers side of the `com.reactnativecommunity:netinfo` artifact, but I believe more consumers of your library might have similar problem of silently depending on alpha version of `androidx.core:core`, which can bring various issues from the nature of the fact it is `alpha` :)

  ### Proposed solution
  - Use explicit version and not the dynamic one to ensure binary and behaviour consistency between builds from the same codebase
  - Latest stable version of `androidx.core:core` is `1.3.2` - https://developer.android.com/jetpack/androidx/releases/core


# Test Plan
- I believe the existing CI building and testing in place should verify the code is built properly with this artifact.
