### PR TITLE
[feat] Add 5g cellular type

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,5 +2,3 @@ ReactNativeNetInfo_compileSdkVersion=29
 ReactNativeNetInfo_buildToolsVersion=29.0.3
 ReactNativeNetInfo_targetSdkVersion=27
 ReactNativeNetInfo_minSdkVersion=16
-android.useAndroidX=true
-android.enableJetifier=true

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
-ReactNativeNetInfo_compileSdkVersion=28
-ReactNativeNetInfo_buildToolsVersion=28.0.3
+ReactNativeNetInfo_compileSdkVersion=29
+ReactNativeNetInfo_buildToolsVersion=29.0.3
 ReactNativeNetInfo_targetSdkVersion=27
 ReactNativeNetInfo_minSdkVersion=16
 android.useAndroidX=true

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,3 +2,5 @@ ReactNativeNetInfo_compileSdkVersion=28
 ReactNativeNetInfo_buildToolsVersion=28.0.3
 ReactNativeNetInfo_targetSdkVersion=27
 ReactNativeNetInfo_minSdkVersion=16
+android.useAndroidX=true
+android.enableJetifier=true

--- a/android/src/main/java/com/reactnativecommunity/netinfo/types/CellularGeneration.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/types/CellularGeneration.java
@@ -16,7 +16,8 @@ public enum CellularGeneration {
     // We need to prefix these with "CG_" because they cannot start with numbers
     CG_2G("2g"),
     CG_3G("3g"),
-    CG_4G("4g");
+    CG_4G("4g"),
+    CG_5G("5g");
 
     public final String label;
 
@@ -49,6 +50,8 @@ public enum CellularGeneration {
             case TelephonyManager.NETWORK_TYPE_HSPAP:
             case TelephonyManager.NETWORK_TYPE_LTE:
                 return CellularGeneration.CG_4G;
+            case TelephonyManager.NETWORK_TYPE_NR:
+                return CellularGeneration.CG_5G;
             case TelephonyManager.NETWORK_TYPE_UNKNOWN:
             default:
                 return null;

--- a/ios/RNCConnectionState.h
+++ b/ios/RNCConnectionState.h
@@ -23,6 +23,7 @@ static NSString *const RNCConnectionTypeEthernet = @"ethernet";
 static NSString *const RNCCellularGeneration2g = @"2g";
 static NSString *const RNCCellularGeneration3g = @"3g";
 static NSString *const RNCCellularGeneration4g = @"4g";
+static NSString *const RNCCellularGeneration5g = @"5g";
 
 @interface RNCConnectionState : NSObject
 

--- a/ios/RNCConnectionState.m
+++ b/ios/RNCConnectionState.m
@@ -62,6 +62,9 @@
                     _cellularGeneration = RNCCellularGeneration3g;
                 } else if ([netinfo.currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyLTE]) {
                     _cellularGeneration = RNCCellularGeneration4g;
+                } else if ([netinfo.currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyNRNSA] ||
+                           [netinfo.currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyNR]) {
+                    _cellularGeneration = RNCCellularGeneration5g;
                 }
             }
         }

--- a/src/__tests__/fetch.spec.ts
+++ b/src/__tests__/fetch.spec.ts
@@ -24,6 +24,68 @@ beforeEach(() => {
 
 describe('@react-native-community/netinfo fetch', () => {
   describe('with cellular data types', () => {
+    describe('5g cellular generation', () => {
+      function dataProvider() {
+        return [
+          {
+            description:
+              'should resolve the promise correctly with expected 5g settings',
+            expectedConnectionInfo: {
+              type: NetInfoStateType.cellular,
+              isConnected: true,
+              isInternetReachable: true,
+              details: {
+                isConnectionExpensive: true,
+                cellularGeneration: NetInfoCellularGeneration['5g'],
+              },
+            },
+          },
+          {
+            description:
+              'should resolve the promise correctly when 5g returns not connected',
+            expectedConnectionInfo: {
+              type: NetInfoStateType.cellular,
+              isConnected: false,
+              isInternetReachable: true,
+              details: {
+                isConnectionExpensive: true,
+                cellularGeneration: NetInfoCellularGeneration['5g'],
+              },
+            },
+          },
+          {
+            description:
+              'should resolve the promise correctly when 5g returns internet not reachable',
+            expectedConnectionInfo: {
+              type: NetInfoStateType.cellular,
+              isConnected: true,
+              isInternetReachable: false,
+              details: {
+                isConnectionExpensive: true,
+                cellularGeneration: NetInfoCellularGeneration['5g'],
+              },
+            },
+          },
+        ];
+      }
+
+      dataProvider().forEach(testCase => {
+        it(testCase.description, () => {
+          mockNativeModule.getCurrentState.mockResolvedValue(
+            testCase.expectedConnectionInfo,
+          );
+
+          NativeInterface.eventEmitter.emit(
+            DEVICE_CONNECTIVITY_EVENT,
+            testCase.expectedConnectionInfo,
+          );
+          expect(NetInfo.fetch()).resolves.toEqual(
+            testCase.expectedConnectionInfo,
+          );
+        });
+      });
+    });
+
     describe('4g cellular generation', () => {
       function dataProvider() {
         return [

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -23,6 +23,7 @@ export enum NetInfoCellularGeneration {
   '2g' = '2g',
   '3g' = '3g',
   '4g' = '4g',
+  '5g' = '5g',
 }
 
 export interface NetInfoConnectedDetails {


### PR DESCRIPTION
# Overview

Adds support for the 5G cellular type on Android and iOS. Intentionally missing Windows changes because the native platform does not have a 5G type yet according to the documentation that @matt-oakes shared in issue #153

JS changes
- Add the 5G enum type
- Add unit tests

Android changes
- Bump compile sdk version to 29 and bump platform tools version to latest 29 to match (required to get access to new enum)
- 

# Test Plan

Blocked on testing. Looking for help from others testing these changes.
I ran into multiple issues building the app on iOS and Android.

For now, I'm just going to open a PR and see if the CI pipeline can validate my changes, because I can't build this project even from the master branch.

On iOS, I get the following build error when building the example iOS app.

```
luis@MacBook-Pro react-native-netinfo % yarn test:detox:ios:build:debug
yarn run v1.22.10
$ detox build -c ios.sim.debug
detox[30363] INFO:  [build.js] export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -project example/ios/NetInfoExample.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 11' -scheme NetInfoExample -parallelizeTargets -configuration Debug -derivedDataPath example/ios/build  -UseModernBuildSystem=YES | xcpretty -k

❌  error: /Users/luis/code/react-native-netinfo/example/ios/Pods/Target Support Files/Pods-NetInfoExample/Pods-NetInfoExample.debug.xcconfig: unable to open file (in target "NetInfoExample" in project "NetInfoExample") (in target 'NetInfoExample' from project 'NetInfoExample')
```

On Android, Android Studio fails to sync gradle due to some missing project files. This prevents the build from working in Android Studio. 

```
Could not read script '/Users/luis/code/react-native-netinfo/example/node_modules/@react-native-community/cli-platform-android/native_modules.gradle' as it does not exist.
```

Trying to build from the command line (using gradlew) yields a cryptic build error (```Could not initialize class org.codehaus.groovy.runtime.InvokerHelper```) that I'm assuming is related to the root cause (missing native_modules.gradle)

Open questions
* Need to test this on Android API 28 (before this enum was introduced) as well as 29 (first API where this was introduced) to ensure these changes are backwards compatible.
* On iOS, there are two 5G related enum [values](https://developer.apple.com/documentation/coretelephony/cttelephonynetworkinfo/radio_access_technology_constants?language=objc) (CTRadioAccessTechnologyNRNSA
 and CTRadioAccessTechnologyNR
). It's not clear if both are desired or not, so I just included both but to be honest I don't totally understand the difference and if that's the right decision or not.
