### PR TITLE
set initial netInfo data in useNetInfo to undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,17 +89,12 @@ export function addEventListener(
  */
 export function useNetInfo(
   configuration?: Partial<Types.NetInfoConfiguration>,
-): Types.NetInfoState {
+): Types.NetInfoState | undefined {
   if (configuration) {
     configure(configuration);
   }
 
-  const [netInfo, setNetInfo] = useState<Types.NetInfoState>({
-    type: Types.NetInfoStateType.unknown,
-    isConnected: false,
-    isInternetReachable: false,
-    details: null,
-  });
+  const [netInfo, setNetInfo] = useState<Types.NetInfoState>();
 
   useEffect((): (() => void) => {
     return addEventListener(setNetInfo);


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

I ran into the same problem described in #405 and thought the proposal in that issue seemed to make sense. I took a quick stab by simple removing the initial state. This is obviously a breaking change as some users of this lib would expect data to be there on first render. 

closes #405 

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Honestly, I didn't test this but it is a straightforward change. I received an error attempting to `yarn install`. If someone is willing to help debug that, I can try to put some more time into testing this PR. 