### PR TITLE
fix(android): isConnected is wrong incorrect for wifi networks only the app has access to

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
@@ -13,6 +13,7 @@ import android.net.LinkProperties;
 import android.net.Network;
 import android.net.NetworkCapabilities;
 import android.net.NetworkInfo;
+import android.net.NetworkRequest;
 import android.os.Build;
 
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -39,7 +40,8 @@ class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
     @SuppressLint("MissingPermission")
     void register() {
         try {
-            getConnectivityManager().registerDefaultNetworkCallback(mNetworkCallback);
+            NetworkRequest.Builder builder = new NetworkRequest.Builder();
+            getConnectivityManager().registerNetworkCallback(builder.build(), mNetworkCallback);
         } catch (SecurityException e) {
             // TODO: Display a yellow box about this
         }


### PR DESCRIPTION
# Overview

Use registerNetworkCallback instead of registerDefaultNetworkCallback as the default method isn't notified of wifi network changes that are available to the app but not the system / other apps.

## Issue

When I use react-native-wifi-reborn to [connect](https://github.com/ThanosFisherman/WifiUtils/blob/master/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConnectorUtils.java#L377) with an IoT wifi network (for commissioning), and I use `fetch`, netinfo returns the correct network information. However the `isConnected` is `false` and the eventListener isn't notified of the change.

After debugging the code I noticed that the [ConnectivityNetworkCallback](https://github.com/react-native-netinfo/react-native-netinfo/blob/master/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java#L118) was never invoked for the new wifi network.

To me it looks like the registerDefaultNetworkCallback only notifies for wifi networks that are available system-wide, while the registerNetworkCallback also for wifi networks that are only available to the app.

Looking at the Android sdk this is what is executed for registerDefaultNetworkCallback:
```
@RequiresPermission(android.Manifest.permission.ACCESS_NETWORK_STATE)
    public void registerDefaultNetworkCallback(@NonNull NetworkCallback networkCallback,
            @NonNull Handler handler) {
        // This works because if the NetworkCapabilities are null,
        // ConnectivityService takes them from the default request.
        //
        // Since the capabilities are exactly the same as the default request's
        // capabilities, this request is guaranteed, at all times, to be
        // satisfied by the same network, if any, that satisfies the default
        // request, i.e., the system default network.
        CallbackHandler cbHandler = new CallbackHandler(handler);
        sendRequestForNetwork(null /* NetworkCapabilities need */, networkCallback, 0,
                REQUEST, TYPE_NONE, cbHandler);
    }
```

While registerNetworkCallback:
```
@RequiresPermission(android.Manifest.permission.ACCESS_NETWORK_STATE)
    public void registerNetworkCallback(@NonNull NetworkRequest request,
            @NonNull NetworkCallback networkCallback, @NonNull Handler handler) {
        CallbackHandler cbHandler = new CallbackHandler(handler);
        NetworkCapabilities nc = request.networkCapabilities;
        sendRequestForNetwork(nc, networkCallback, 0, LISTEN, TYPE_NONE, cbHandler);
    }
```

The default networkcapabilities are:
```
/**
     * Capabilities that are set by default when the object is constructed.
     */
    private static final long DEFAULT_CAPABILITIES =
            (1 << NET_CAPABILITY_NOT_RESTRICTED) |
            (1 << NET_CAPABILITY_TRUSTED) |
            (1 << NET_CAPABILITY_NOT_VPN);
```

Looking at the code the issue is that when fetching wifi data, the WifiManager is used to fetch fields like ssid, bssid, frequency, ... . The isConnected indicates false because the variable [mConnectionType](https://github.com/react-native-netinfo/react-native-netinfo/blob/master/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java#L41) is actually `NONE`. Also, important to notice is, that if you have a mobile connection, it's actually true if that connection is active.

# Related issues

* Fixes https://github.com/react-native-netinfo/react-native-netinfo/issues/411
* https://github.com/JuanSeBestia/react-native-wifi-reborn/issues/123

# Test Plan

Running a simple test; connect via react-native-wifi-reborn to a wifi network, call `Netinfo.fetch()` and see if wifi details + isConnected are correct.
Also checking if NetInfo.addEventListener is updated of the change.

Currently tested on:
* Samsung Galaxy S10 (Android 11) ☑️
* Huawei P10 (Android 10) ☑️
* Pixel 2 (Android 10) ☑️
