### PR TITLE
fix(useNetinfo): do not return false on initial unknown state

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Describes the current state of the network. It is an object with these propertie
 | Property              | Type                                    | Description                                                                                        |
 | --------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | `type`                | [`NetInfoStateType`](#netinfostatetype) | The type of the current connection.                                                                |
-| `isConnected`         | `boolean`                               | If there is an active network connection. Note that this DOES NOT mean that internet is reachable. |
+| `isConnected`         | `boolean`, `null`                               | If there is an active network connection. If unknown defaults to `null`. |
 | `isInternetReachable` | `boolean`, `null`                             | If the internet is reachable with the currently active network connection. If unknown defaults to `null`                         |
 | `isWifiEnabled`       | `boolean`                               | *(Android only)* Whether the device's WiFi is ON or OFF.                                           |
 | `details`             |                                         | The value depends on the `type` value. See below.                                                  |

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Describes the current state of the network. It is an object with these propertie
 | --------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | `type`                | [`NetInfoStateType`](#netinfostatetype) | The type of the current connection.                                                                |
 | `isConnected`         | `boolean`                               | If there is an active network connection. Note that this DOES NOT mean that internet is reachable. |
-| `isInternetReachable` | `boolean`                               | If the internet is reachable with the currently active network connection.                         |
+| `isInternetReachable` | `boolean`, `null`                             | If the internet is reachable with the currently active network connection. If unknown defaults to `null`                         |
 | `isWifiEnabled`       | `boolean`                               | *(Android only)* Whether the device's WiFi is ON or OFF.                                           |
 | `details`             |                                         | The value depends on the `type` value. See below.                                                  |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ export function useNetInfo(
 
   const [netInfo, setNetInfo] = useState<Types.NetInfoState>({
     type: Types.NetInfoStateType.unknown,
-    isConnected: false,
+    isConnected: null,
     isInternetReachable: null,
     details: null,
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ export function useNetInfo(
   const [netInfo, setNetInfo] = useState<Types.NetInfoState>({
     type: Types.NetInfoStateType.unknown,
     isConnected: false,
-    isInternetReachable: false,
+    isInternetReachable: null,
     details: null,
   });
 

--- a/src/internal/internetReachability.ts
+++ b/src/internal/internetReachability.ts
@@ -31,7 +31,7 @@ export default class InternetReachability {
   }
 
   private _setIsInternetReachable = (
-    isInternetReachable: boolean | null | undefined,
+    isInternetReachable: boolean | null,
   ): void => {
     if (this._isInternetReachable === isInternetReachable) {
       return;

--- a/src/internal/internetReachability.ts
+++ b/src/internal/internetReachability.ts
@@ -41,7 +41,7 @@ export default class InternetReachability {
     this._listener(this._isInternetReachable);
   };
 
-  private _setExpectsConnection = (expectsConnection: boolean): void => {
+  private _setExpectsConnection = (expectsConnection: boolean | null): void => {
     // Cancel any pending check
     if (this._currentInternetReachabilityCheckHandler !== null) {
       this._currentInternetReachabilityCheckHandler.cancel();

--- a/src/internal/nativeModule.web.ts
+++ b/src/internal/nativeModule.web.ts
@@ -214,7 +214,7 @@ const getCurrentState = (
     const state: NetInfoUnknownState = {
       ...baseState,
       isConnected: false,
-      isInternetReachable: false,
+      isInternetReachable: null,
       type,
       details: null,
     };

--- a/src/internal/nativeModule.web.ts
+++ b/src/internal/nativeModule.web.ts
@@ -213,7 +213,7 @@ const getCurrentState = (
   } else if (type === NetInfoStateType.unknown) {
     const state: NetInfoUnknownState = {
       ...baseState,
-      isConnected: false,
+      isConnected: null,
       isInternetReachable: null,
       type,
       details: null,

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -35,7 +35,7 @@ interface NetInfoConnectedState<
 > {
   type: T;
   isConnected: true;
-  isInternetReachable: boolean | null | undefined;
+  isInternetReachable: boolean | null;
   details: D & NetInfoConnectedDetails;
   isWifiEnabled?: boolean;
 }

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -49,7 +49,7 @@ interface NetInfoDisconnectedState<T extends NetInfoStateType> {
 
 export interface NetInfoUnknownState {
   type: NetInfoStateType.unknown;
-  isConnected: false;
+  isConnected: null;
   isInternetReachable: null;
   details: null;
 }

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -47,9 +47,13 @@ interface NetInfoDisconnectedState<T extends NetInfoStateType> {
   details: null;
 }
 
-export type NetInfoUnknownState = NetInfoDisconnectedState<
-  NetInfoStateType.unknown
->;
+export interface NetInfoUnknownState {
+  type: NetInfoStateType.unknown;
+  isConnected: false;
+  isInternetReachable: null;
+  details: null;
+}
+
 export type NetInfoNoConnectionState = NetInfoDisconnectedState<
   NetInfoStateType.none
 >;


### PR DESCRIPTION
# Overview
The hook [`useNetInfo` ](https://github.com/react-native-netinfo/react-native-netinfo#usenetinfo) returns the [NetInfoState](https://github.com/react-native-netinfo/react-native-netinfo/blob/master/README.md#netinfostate).
On the first initial call some state values are still unknown. 
Therefore the **type** `unknown` is defined in the initial NetInfoState in this hook.
=> See [docs here](https://github.com/react-native-netinfo/react-native-netinfo/blob/master/README.md#netinfostatetype)
=> See [code here](https://github.com/react-native-netinfo/react-native-netinfo/blob/master/src/index.ts#L98)

### PROBLEM
However, the NetInfoState values `isConnected` and `isInternetReachable` are already defined as `false` within the initial state even though their actual values have not been determined yet (=> see code [here](https://github.com/react-native-netinfo/react-native-netinfo/blob/master/src/index.ts#L99-L100)). 
This can lead to **false negative** assumptions when using this hook as described already in https://github.com/react-native-netinfo/react-native-netinfo/issues/295.

### SOLUTION

This PR defines an altered `unknown` state on initial hook-call with:
- set initial `isConnected` to `null`
- set initial `isInternetReachable` to `null` (=> also better aligned with [this case](https://github.com/react-native-netinfo/react-native-netinfo/blob/master/src/internal/internetReachability.ts#L57-L60))
- adjust types accordingly
- adjust docs accordingly

This will ensure to be certain that if:
- the type is still `unknown`
- `isConnected` is not of type `boolean`
- `isInternetReachable` is not of type `boolean`
- => **The final NetinfoState has not been determined yet.**

### HOW TO USE
Still, this does not replace work-arounds when relying on the final determined netInfoState.
When using this hook one might still need to know if the netInfoState is ready with wrapping it in another hook like:
```TS
export const useGetNetInfoState: () => false | NetInfoState = () => {
  const [isLoading, setIsLoading] = useState(true);

  const netInfoState = NetInfo.useNetInfo();
  const { type, isInternetReachable } = netInfoState;

  useEffect(() => {
    if (type !== 'unknown' && typeof isInternetReachable === 'boolean') {
      setIsLoading(false);
    }
  }, [type, isInternetReachable]);

  return !isLoading && netInfoState;
};
```
### Related Issue
https://github.com/react-native-netinfo/react-native-netinfo/issues/295


### Additional Information
I started to refactor the complete hook `useNetInfo` with either returning the final determined `NetInfoState` or `null`.
This would have been made the `unknown` state completeley obsolete in the end and might lead to even bigger breaking changes for other users than this PR. Still, let me know if this would be a good way to go.

# Test Plan
I did not find any tests for the hook `useNetinfo`. But `yarn tests` runs through and I tested this change with a running app. Does that count 😃 ? 
