### PR TITLE
Fix assembleAndroidTest builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,6 +31,11 @@ apply plugin: 'com.android.library'
 android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
 
+  compileOptions {
+      sourceCompatibility JavaVersion.VERSION_1_8
+      targetCompatibility JavaVersion.VERSION_1_8
+  }
+
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Fixes an issue when building and running instrumented tests (e.g. Detox) for a React Native project on Android, the following build error was occurring:

```
Execution failed for task ':react-native-community_netinfo:mergeExtDexDebugAndroidTest'.
> Could not resolve all files for configuration ':react-native-community_netinfo:debugAndroidTestRuntimeClasspath'.
   > Failed to transform core-1.6.0-alpha03.aar (androidx.core:core:1.6.0-alpha03) to match attributes {artifactType=android-dex, dexing-enable-desugaring=false, dexing-is-debuggable=true, dexing-min-sdk=23, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=aar, org.gradle.status=release, org.gradle.usage=java-runtime}.
```

If an Android library uses Java 8 language features then it must declare `compileOptions` in its `build.gradle`.

> ...each module that uses Java 8 language features (either in its source code or through dependencies), update the module's build.gradle file, as shown below:

https://developer.android.com/studio/write/java8-support#supported_features

Fix is simple to add Java 8 `compileOptions` to the `build.gradle`. I've seen and fixed similar issues in other projects as well:

https://github.com/negativetwelve/react-native-ux-cam/issues/104
https://github.com/snowplow-incubator/snowplow-react-native-tracker/pull/117

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Made the change locally in my projects `node_modules`, then rebuilt the app, and it was successful 🎉 .
