### PR TITLE
Add handling in case of automatic network switch

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
@@ -15,6 +15,7 @@ import android.net.NetworkCapabilities;
 import android.net.NetworkInfo;
 import android.net.NetworkRequest;
 import android.os.Build;
+import android.content.Context;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.reactnativecommunity.netinfo.types.CellularGeneration;
@@ -30,10 +31,12 @@ class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
     private final ConnectivityNetworkCallback mNetworkCallback;
     Network mNetwork = null;
     NetworkCapabilities mNetworkCapabilities = null;
+    public ConnectivityManager connection;
 
     public NetworkCallbackConnectivityReceiver(ReactApplicationContext reactContext) {
         super(reactContext);
         mNetworkCallback = new ConnectivityNetworkCallback();
+        connection = (ConnectivityManager) reactContext.getSystemService(Context.CONNECTIVITY_SERVICE);
     }
 
     @Override
@@ -103,6 +106,10 @@ class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
                             && mNetworkCapabilities.hasCapability(
                             NetworkCapabilities.NET_CAPABILITY_VALIDATED)
                             && !isInternetSuspended;
+
+            if (isInternetReachable) {
+                connection.bindProcessToNetwork(null);
+            }
 
             // Get the cellular network type
             if (mNetwork != null && connectionType == ConnectionType.CELLULAR && isInternetReachable) {


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

I managed to handle the case when disconnecting from a WiFi network from code and the phone automatically attaches to a known WiFi network. Without this modification, when it switches, it is not able to make requests.
