### PR TITLE
test(mock): useNetInfo should not return a promise

### DIFF
--- a/jest/netinfo-mock.js
+++ b/jest/netinfo-mock.js
@@ -21,6 +21,6 @@ const RNCNetInfoMock = {
 };
 
 RNCNetInfoMock.fetch.mockResolvedValue(defaultState);
-RNCNetInfoMock.useNetInfo.mockResolvedValue(defaultState);
+RNCNetInfoMock.useNetInfo.mockReturnValue(defaultState);
 
 module.exports = RNCNetInfoMock;


### PR DESCRIPTION
# Overview
`useNetInfo` resolves a promise in the Jest mocks for the library. This is not correct if looking at the types of useNetInfo. This is a small change to make sure jest mocks the hooks correctly.

https://github.com/react-native-netinfo/react-native-netinfo/blob/371acf957cb25275395a268fd61a285e60a01acf/src/index.ts#L97-L108

https://github.com/react-native-netinfo/react-native-netinfo/blob/371acf957cb25275395a268fd61a285e60a01acf/src/internal/types.ts#L104
