### PR TITLE
fixed warnings 'new NativeEventEmitter() was called with a non-null a…

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoModule.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoModule.java
@@ -59,4 +59,14 @@ public class NetInfoModule extends ReactContextBaseJavaModule implements AmazonF
     public void onAmazonFireDeviceConnectivityChanged(boolean isConnected) {
         mConnectivityReceiver.setIsInternetReachableOverride(isConnected);
     }
+
+    @ReactMethod
+    public void addListener(String eventName) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
 }

--- a/ios/RNCNetInfo.m
+++ b/ios/RNCNetInfo.m
@@ -251,4 +251,12 @@ RCT_EXPORT_METHOD(getCurrentState:(nullable NSString *)requestedInterface resolv
 }
 #endif
 
+RCT_EXPORT_METHOD(addListener : (NSString *)eventName) {
+  // Keep: Required for RN built in Event Emitter Calls.
+}
+
+RCT_EXPORT_METHOD(removeListeners : (NSInteger)count) {
+  // Keep: Required for RN built in Event Emitter Calls.
+}
+
 @end


### PR DESCRIPTION
…rgument without the required addListener and removeListener methods' on react-native 0.65 and android platform

# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
This PR fix warns
WARN new NativeEventEmitter() was called with a non-null argument without the required addListener method.
WARN new NativeEventEmitter() was called with a non-null argument without the required removeListeners method.
on Android platform with react-native 0.65 (0.65.0, 0.65.1, and probably next higher versions)
Issue: https://github.com/react-native-netinfo/react-native-netinfo/issues/486

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
