### PR TITLE
Use NWPathMonitor for iOS/macOS

### DIFF
--- a/ios/RNCConnectionState.h
+++ b/ios/RNCConnectionState.h
@@ -7,6 +7,7 @@
 
 #import <Foundation/Foundation.h>
 #import <SystemConfiguration/SystemConfiguration.h>
+@import Network;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -27,7 +28,7 @@ static NSString *const RNCCellularGeneration4g = @"4g";
 @interface RNCConnectionState : NSObject
 
 - (instancetype)init;
-- (instancetype)initWithReachabilityFlags:(SCNetworkReachabilityFlags)flags;
+- (instancetype)initWithPath:(nw_path_t)path;
 - (BOOL)isEqualToConnectionState:(RNCConnectionState *)otherState;
 
 @property (nonatomic, strong, readonly) NSString *type;

--- a/ios/RNCConnectionStateWatcher.h
+++ b/ios/RNCConnectionStateWatcher.h
@@ -22,7 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RNCConnectionStateWatcher : NSObject
 
 - (instancetype)initWithDelegate:(id<RNCConnectionStateWatcherDelegate>)delegate;
-- (RNCConnectionState *)currentState;
+
+@property (nonnull, strong, nonatomic, readonly) RNCConnectionState *state;
 
 @end
 

--- a/ios/RNCNetInfo.m
+++ b/ios/RNCNetInfo.m
@@ -55,7 +55,9 @@ RCT_EXPORT_MODULE()
 
 - (void)startObserving
 {
-  self.isObserving = YES;
+    self.isObserving = YES;
+    NSDictionary *dictionary = [self currentDictionaryFromUpdateState:_connectionStateWatcher.state withInterface:NULL];
+    [self sendEventWithName:@"netInfo.networkStatusDidChange" body:dictionary];
 }
 
 - (void)stopObserving
@@ -92,7 +94,7 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(getCurrentState:(nullable NSString *)requestedInterface resolve:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject)
 {
-  RNCConnectionState *state = [self.connectionStateWatcher currentState];
+  RNCConnectionState *state = self.connectionStateWatcher.state;
   resolve([self currentDictionaryFromUpdateState:state withInterface:requestedInterface]);
 }
 

--- a/react-native-netinfo.podspec
+++ b/react-native-netinfo.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platforms    = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" }
+  s.platforms    = { :ios => "12.0", :tvos => "12.0", :osx => "10.14" }
 
   s.source       = { :git => "https://github.com/react-native-community/react-native-netinfo.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

The network type for ethernet was reported incorrectly on macOS.

Since there's a new API [NWPathMonitor](https://developer.apple.com/documentation/network/nwpathmonitor) (introduced in iOS 12/macOS 10.14) to detect network connectivity changes, I rewrote ios network state watching using this API. 


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

I'm blocked on testing on the example project because the build is failing on the latest Xcode (likely due to an outdated RN version). Here's what I get on Xcode 12.5.1:
<img width="554" alt="Screen Shot 2021-09-20 at 6 04 14 PM" src="https://user-images.githubusercontent.com/1094629/134097025-f739cab4-4e5a-4359-b2fa-cf4eff279147.png">

https://user-images.githubusercontent.com/1094629/134097094-ed289262-c1e6-4cba-b979-6e290d1ff0d8.mov

Tests:
- connect to WiFI network
- check that the network connectivity state is reported correctly - connected, wifi
- Turn off WiFi
- check that the network connectivity state is reported correctly - disconnected

- connect to ethernet
- check that the network connectivity state & network type is reported correctly - connected, ethernet
- disconnect from ethernet
- check that the network connectivity state is reported correctly - disconnected

