### PR TITLE
register receiver on Application context

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/AmazonFireDeviceConnectivityPoller.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/AmazonFireDeviceConnectivityPoller.java
@@ -90,7 +90,7 @@ public class AmazonFireDeviceConnectivityPoller {
         IntentFilter filter = new IntentFilter();
         filter.addAction(ACTION_INTERNET_DOWN);
         filter.addAction(ACTION_INTERNET_UP);
-        context.registerReceiver(receiver, filter);
+        context.getApplicationContext().registerReceiver(receiver, filter);
 
         receiver.registered = true;
     }


### PR DESCRIPTION
this is giving :

android.content.ReceiverCallNotAllowedException: 
  at android.app.ReceiverRestrictedContext.registerReceiver (ContextImpl.java:155)
  at android.app.ReceiverRestrictedContext.registerReceiver (ContextImpl.java:144)

# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
