### PR TITLE
fix(jest): mock return value not resolve value for useNetInfo mock

### DIFF
--- a/jest/netinfo-mock.js
+++ b/jest/netinfo-mock.js
@@ -21,6 +21,6 @@ const RNCNetInfoMock = {
 };
 
 RNCNetInfoMock.fetch.mockResolvedValue(defaultState);
-RNCNetInfoMock.useNetInfo.mockResolvedValue(defaultState);
+RNCNetInfoMock.useNetInfo.mockReturnValue(defaultState);
 
 module.exports = RNCNetInfoMock;


### PR DESCRIPTION
# Overview
Changed the mocked return for the `useNetInfo` to return direct state instead of promise<state>

# Test Plan
* Right now: see if any breaks.. 

Fixes #514

## Help?
* This might break someone tests when they update this package.. so its a minor update perhaps?