### PR TITLE
test(example): use cross-platform path style

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "MIT",
   "scripts": {
     "start": "react-native start",
+    "start:android": "cd example && yarn react-native run-android",
     "start:ios": "cd example && yarn react-native run-ios --project-path `pwd`/ios",
     "start:macos": "node node_modules/react-native-macos/local-cli/cli.js start --use-react-native-macos",
     "start:web": "webpack-dev-server --config example/webpack.config.js",

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -14,6 +14,8 @@
  * and conversely metro.config.macos.js has to blacklist 'node_modules/react-native'.
  */
 'use strict';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const path = require('path');
 
 const macSwitch = '--use-react-native-macos';
 const windowsSwitch = '--use-react-native-windows';
@@ -27,10 +29,10 @@ let config = {
       sourceDir: 'example/android',
     },
     windows:{
-      sourceDir: 'example\\windows',
+      sourceDir: path.join('example', 'windows'),
       solutionFile: 'NetInfoExample.sln',
       project: {
-          projectFile: 'NetInfoExample\\NetInfoExample.vcxproj',
+          projectFile: path.join('NetInfoExample', 'NetInfoExample.vcxproj'),
       },
     },
   },


### PR DESCRIPTION
# Overview

without this the example won't run on non-windows platforms

Silly Windows coders ;-) @tero-paananen / @jonthysell (I kid, this is the exact sort of error I make in the other direction)

Related #521 / https://github.com/react-native-netinfo/react-native-netinfo/pull/521/files#diff-8be869fd4628b75fa5a2b47a309cc53741d78a47478966dc3e4b3c50ffce00d9 

# Test Plan

`yarn && yarn ios` should work on a macOS machine

Hopefully Tero or Jon can give it a look to make sure I haven't made it work on macOS but busted it for Windows