### PR TITLE
feat(background-data): query, publish, and listen to background data restriction status

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/BroadcastReceiverConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/BroadcastReceiverConnectivityReceiver.java
@@ -95,7 +95,7 @@ public class BroadcastReceiverConnectivityReceiver extends ConnectivityReceiver 
             connectionType = ConnectionType.UNKNOWN;
         }
 
-        updateConnectivity(connectionType, cellularGeneration, isInternetReachable);
+        updateConnectivity(connectionType, cellularGeneration, isInternetReachable, ConnectivityManager.RESTRICT_BACKGROUND_STATUS_DISABLED);
     }
 
     /**

--- a/src/__tests__/eventListenerCallbacks.spec.ts
+++ b/src/__tests__/eventListenerCallbacks.spec.ts
@@ -11,7 +11,11 @@ import fetchMock from 'jest-fetch-mock';
 import NetInfo from '../index';
 import NativeInterface from '../internal/nativeInterface';
 import {DEVICE_CONNECTIVITY_EVENT} from '../internal/privateTypes';
-import {NetInfoStateType, NetInfoCellularGeneration} from '../internal/types';
+import {
+  NetInfoBackgroundRefreshSetting,
+  NetInfoStateType,
+  NetInfoCellularGeneration,
+} from '../internal/types';
 
 // Mock modules
 fetchMock.enableMocks();
@@ -23,6 +27,7 @@ beforeAll(() => {
     type: NetInfoStateType.cellular,
     isConnected: true,
     isInternetReachable: true,
+    expectedBackgroundRefreshStatus: NetInfoBackgroundRefreshSetting.available,
     details: {
       isConnectionExpensive: true,
       cellularGeneration: NetInfoCellularGeneration['4g'],
@@ -59,12 +64,15 @@ describe('@react-native-community/netinfo listener', () => {
       const listener = jest.fn();
       NetInfo.addEventListener(listener);
 
-      const expectedConnectionType = 'wifi';
-      const expectedEffectiveConnectionType = 'unknown';
+      const expectedConnectionType = NetInfoStateType.wifi;
+      const expectedEffectiveConnectionType = NetInfoStateType.unknown;
+      const expectedBackgroundRefreshStatus =
+        NetInfoBackgroundRefreshSetting.available;
       const expectedConnectionInfo = {
         type: expectedConnectionType,
         isConnected: true,
         isInternetReachable: true,
+        backgroundRefresh: expectedBackgroundRefreshStatus,
         details: {
           isConnectionExpensive: true,
           cellularGeneration: expectedEffectiveConnectionType,
@@ -84,17 +92,17 @@ describe('@react-native-community/netinfo listener', () => {
       NetInfo.addEventListener(listener);
 
       const cellularInfo = {
-        type: 'cellular',
+        type: NetInfoStateType.cellular,
         isConnected: true,
         isInternetReachable: true,
         details: {
           isConnectionExpensive: true,
-          cellularGeneration: '3g',
+          cellularGeneration: NetInfoCellularGeneration['3g'],
         },
       };
 
       const wifiInfo = {
-        type: 'wifi',
+        type: NetInfoStateType.wifi,
         isConnected: true,
         isInternetReachable: true,
         details: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,7 @@ export function useNetInfo(
     type: Types.NetInfoStateType.unknown,
     isConnected: null,
     isInternetReachable: null,
+    backgroundRefresh: Types.NetInfoBackgroundRefreshSetting.unknown,
     details: null,
   });
 

--- a/src/internal/nativeModule.web.ts
+++ b/src/internal/nativeModule.web.ts
@@ -24,6 +24,7 @@ import {
   NetInfoWimaxState,
   NetInfoOtherState,
   NetInfoCellularGeneration,
+  NetInfoBackgroundRefreshSetting,
 } from './types';
 
 // See https://wicg.github.io/netinfo/#dom-connectiontype
@@ -115,6 +116,7 @@ const getCurrentState = (
         ...baseState,
         isConnected: true,
         type: NetInfoStateType.other,
+        backgroundRefresh: NetInfoBackgroundRefreshSetting.unknown,
         details: {
           isConnectionExpensive: false,
         },
@@ -127,6 +129,7 @@ const getCurrentState = (
       isConnected: false,
       isInternetReachable: false,
       type: NetInfoStateType.none,
+      backgroundRefresh: NetInfoBackgroundRefreshSetting.unknown,
       details: null,
     };
     return state;
@@ -145,6 +148,7 @@ const getCurrentState = (
       ...baseState,
       isConnected: true,
       type,
+      backgroundRefresh: NetInfoBackgroundRefreshSetting.unknown,
       details: {
         isConnectionExpensive,
       },
@@ -155,6 +159,7 @@ const getCurrentState = (
       ...baseState,
       isConnected: true,
       type,
+      backgroundRefresh: NetInfoBackgroundRefreshSetting.unknown,
       details: {
         isConnectionExpensive,
         cellularGeneration:
@@ -168,6 +173,7 @@ const getCurrentState = (
       ...baseState,
       isConnected: true,
       type,
+      backgroundRefresh: NetInfoBackgroundRefreshSetting.unknown,
       details: {
         isConnectionExpensive,
         ipAddress: null,
@@ -180,6 +186,7 @@ const getCurrentState = (
       ...baseState,
       isConnected: true,
       type,
+      backgroundRefresh: NetInfoBackgroundRefreshSetting.unknown,
       details: {
         isConnectionExpensive,
         ssid: null,
@@ -196,6 +203,7 @@ const getCurrentState = (
       ...baseState,
       isConnected: true,
       type,
+      backgroundRefresh: NetInfoBackgroundRefreshSetting.unknown,
       details: {
         isConnectionExpensive,
       },
@@ -207,6 +215,7 @@ const getCurrentState = (
       isConnected: false,
       isInternetReachable: false,
       type,
+      backgroundRefresh: NetInfoBackgroundRefreshSetting.unknown,
       details: null,
     };
     return state;
@@ -216,6 +225,7 @@ const getCurrentState = (
       isConnected: null,
       isInternetReachable: null,
       type,
+      backgroundRefresh: NetInfoBackgroundRefreshSetting.unknown,
       details: null,
     };
     return state;
@@ -225,6 +235,7 @@ const getCurrentState = (
     ...baseState,
     isConnected: true,
     type: NetInfoStateType.other,
+    backgroundRefresh: NetInfoBackgroundRefreshSetting.unknown,
     details: {
       isConnectionExpensive,
     },

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -16,6 +16,7 @@ export enum NetInfoStateType {
   ethernet = 'ethernet',
   wimax = 'wimax',
   vpn = 'vpn',
+  backgroundRefresh = 'backgroundRefresh',
   other = 'other',
 }
 
@@ -24,6 +25,15 @@ export enum NetInfoCellularGeneration {
   '3g' = '3g',
   '4g' = '4g',
   '5g' = '5g',
+}
+
+export enum NetInfoBackgroundRefreshSetting {
+  'unknown' = 'unknown',
+  'available' = 'available',
+  'denied' = 'denied',
+  'denied_if_metered' = 'denied_if_metered',
+  'restricted' = 'restricted',
+  'allowlist' = 'allowlist',
 }
 
 export interface NetInfoConnectedDetails {
@@ -37,6 +47,7 @@ interface NetInfoConnectedState<
   type: T;
   isConnected: true;
   isInternetReachable: boolean | null;
+  backgroundRefresh: NetInfoBackgroundRefreshSetting;
   details: D & NetInfoConnectedDetails;
   isWifiEnabled?: boolean;
 }
@@ -45,6 +56,7 @@ interface NetInfoDisconnectedState<T extends NetInfoStateType> {
   type: T;
   isConnected: false;
   isInternetReachable: false;
+  backgroundRefresh: NetInfoBackgroundRefreshSetting;
   details: null;
 }
 
@@ -52,6 +64,7 @@ export interface NetInfoUnknownState {
   type: NetInfoStateType.unknown;
   isConnected: null;
   isInternetReachable: null;
+  backgroundRefresh: NetInfoBackgroundRefreshSetting;
   details: null;
 }
 
@@ -90,6 +103,12 @@ export type NetInfoEthernetState = NetInfoConnectedState<
     subnet: string | null;
   }
 >;
+export type NetInfoBackgroundRefreshState = NetInfoConnectedState<
+  NetInfoStateType.backgroundRefresh,
+  {
+    backgroundRefresh: NetInfoBackgroundRefreshState | null;
+  }
+>;
 export type NetInfoWimaxState = NetInfoConnectedState<NetInfoStateType.wimax>;
 export type NetInfoVpnState = NetInfoConnectedState<NetInfoStateType.vpn>;
 export type NetInfoOtherState = NetInfoConnectedState<NetInfoStateType.other>;
@@ -100,6 +119,7 @@ export type NetInfoConnectedStates =
   | NetInfoEthernetState
   | NetInfoWimaxState
   | NetInfoVpnState
+  | NetInfoBackgroundRefreshState
   | NetInfoOtherState;
 
 export type NetInfoState = NetInfoDisconnectedStates | NetInfoConnectedStates;


### PR DESCRIPTION
# Overview

This lets you get background data restriction status on android and ios

On android it attempts to listen for broadcasts related to the same, and should emit events when the background data restrictions change

# Test Plan

Works great for initial state fetch on iOS and Android
Works great for state updates as you toggle settings in android and iOS the hook fires in the example app and you can see new values

Need to check the spec used by jest as it seemed I could falsify all the expected states that were unrelated to this even, and it still passed
