### PR TITLE
feat(android, native): make native API public for mixed-native use

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -28,7 +28,7 @@ import java.util.Locale;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-abstract class ConnectivityReceiver {
+public abstract class ConnectivityReceiver {
 
     private final ConnectivityManager mConnectivityManager;
     private final WifiManager mWifiManager;
@@ -53,9 +53,9 @@ abstract class ConnectivityReceiver {
                 (TelephonyManager) reactContext.getSystemService(Context.TELEPHONY_SERVICE);
     }
 
-    abstract void register();
+    public abstract void register();
 
-    abstract void unregister();
+    public abstract void unregister();
 
     public void getCurrentState(@Nullable final String requestedInterface, final Promise promise) {
         promise.resolve(createConnectivityEventMap(requestedInterface));
@@ -100,13 +100,13 @@ abstract class ConnectivityReceiver {
         }
     }
 
-    private void sendConnectivityChangedEvent() {
+    protected void sendConnectivityChangedEvent() {
         getReactContext()
                 .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                 .emit("netInfo.networkStatusDidChange", createConnectivityEventMap(null));
     }
 
-    private WritableMap createConnectivityEventMap(@Nullable final String requestedInterface) {
+    protected WritableMap createConnectivityEventMap(@Nullable final String requestedInterface) {
         WritableMap event = Arguments.createMap();
 
         // Add if WiFi is ON or OFF

--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
@@ -26,7 +26,7 @@ import com.reactnativecommunity.netinfo.types.ConnectionType;
  * it.
  */
 @TargetApi(Build.VERSION_CODES.N)
-class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
+public class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
     private final ConnectivityNetworkCallback mNetworkCallback;
 
     public NetworkCallbackConnectivityReceiver(ReactApplicationContext reactContext) {
@@ -36,7 +36,7 @@ class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
 
     @Override
     @SuppressLint("MissingPermission")
-    void register() {
+    public void register() {
         try {
             NetworkRequest.Builder builder = new NetworkRequest.Builder();
             getConnectivityManager().registerNetworkCallback(builder.build(), mNetworkCallback);
@@ -46,7 +46,7 @@ class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
     }
 
     @Override
-    void unregister() {
+    public void unregister() {
         try {
             getConnectivityManager().unregisterNetworkCallback(mNetworkCallback);
         } catch (SecurityException e) {


### PR DESCRIPTION
# Overview

This allows brown-field or mixed react-native/native apps to call netinfo
APIs and update the connectivity map etc


# Test Plan

Not really testable but i have a work app that uses these interfaces on the native side, and they simply don't compile without these changes
