### PR TITLE
fix(ios, 5g): do not use 5g symbols until iOS14.1

### DIFF
--- a/ios/RNCConnectionState.m
+++ b/ios/RNCConnectionState.m
@@ -67,8 +67,6 @@
                         [netinfo.currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyNR]) {
                         _cellularGeneration = RNCCellularGeneration5g;
                     }
-                } else {
-                    // Fallback on earlier versions
                 }
             }
         }

--- a/ios/RNCConnectionState.m
+++ b/ios/RNCConnectionState.m
@@ -62,9 +62,13 @@
                     _cellularGeneration = RNCCellularGeneration3g;
                 } else if ([netinfo.currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyLTE]) {
                     _cellularGeneration = RNCCellularGeneration4g;
-                } else if ([netinfo.currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyNRNSA] ||
-                           [netinfo.currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyNR]) {
-                    _cellularGeneration = RNCCellularGeneration5g;
+                } else if (@available(iOS 14.1, *)) {
+                    if ([netinfo.currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyNRNSA] ||
+                        [netinfo.currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyNR]) {
+                        _cellularGeneration = RNCCellularGeneration5g;
+                    }
+                } else {
+                    // Fallback on earlier versions
                 }
             }
         }


### PR DESCRIPTION
# Overview

While I was working in the module I saw the warning that we were touching symbols only available on iOS14.1 with no guard, that will crash on older iOS

# Test Plan

Ask for testers from #436 and #417 