### PR TITLE
style(example): fix scrollview jitter in example app

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -175,8 +175,8 @@ class ExampleApp extends React.Component<Record<string, unknown>, State> {
   render() {
     const {activeTestCase} = this.state;
     return (
-      <ScrollView testID="scrollView" style={styles.container}>
-        <SafeAreaView>
+      <SafeAreaView style={styles.container}>
+        <ScrollView testID="scrollView">
           {activeTestCase ? (
             <>
               <Text testID="testCasesTitle" style={styles.sectionTitle}>
@@ -192,8 +192,8 @@ class ExampleApp extends React.Component<Record<string, unknown>, State> {
               {EXAMPLES.map(this._renderExample)}
             </>
           )}
-        </SafeAreaView>
-      </ScrollView>
+        </ScrollView>
+      </SafeAreaView>
     );
   }
 


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Hello and thank you for creating/maintaining this package.

I'm not a very experienced dev, so please forgive me for any missteps in this PR.

The purpose of this is to fix some jittering I noticed when running the example app on the iOS emulator (see the video below). I also took the liberty of pretty-printing the JSON output for each of the examples, but perhaps this isn't the preference for this project for one reason or another. While setting this up I also bumped the `netinfo` version in the podfile.

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

I've tested these changes in the iOS, Android and web examples. Below are videos and screenshots of before and after:

**Output without pretty-printing**

<img width="296" src="https://user-images.githubusercontent.com/20589109/142200765-cff7f119-a279-4353-9a72-3e7ecf8e918c.png" />

**Pretty-printed output**

<img width="296" src="https://user-images.githubusercontent.com/20589109/142200396-9ae214f4-f7e6-4527-a241-d1dce1a4feca.png" />

**Scroll jittering**

![video](https://user-images.githubusercontent.com/20589109/142201429-d9f03696-e7a6-4c61-9453-b32d57738973.mov)

**Scroll jittering removed**

![video](https://user-images.githubusercontent.com/20589109/142202165-f9c53c10-7d30-41c1-929f-60743395ac55.mov)




