### PR TITLE
chore(release): do not run publish workflow on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn test
   deploy:
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: github.repository == 'react-native-netinfo/react-native-netinfo' && github.ref == 'refs/heads/master'
     needs: test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Overview

When I do development I am typically a fork-based workflow, and the publish tries to run when I merge things to the main branch on my fork

This should stop that

# Test Plan

I merged it on master branch on my fork and it no longer attempted to deploy https://github.com/mikehardy/react-native-netinfo/actions/runs/1472040957

The final test is that it does run the deploy here when merged (though with a "chore" tag hopefully it does not release...)