### PR TITLE
fix(jest, mock): addEventListener mock returns a function to match API

### DIFF
--- a/jest/netinfo-mock.js
+++ b/jest/netinfo-mock.js
@@ -22,5 +22,6 @@ const RNCNetInfoMock = {
 
 RNCNetInfoMock.fetch.mockResolvedValue(defaultState);
 RNCNetInfoMock.useNetInfo.mockReturnValue(defaultState);
+RNCNetInfoMock.addEventListener.mockReturnValue(jest.fn());
 
 module.exports = RNCNetInfoMock;


### PR DESCRIPTION
# Overview

`NetInfo.addEventListener()` returns `unsubscribe` function from actual api, but corresponding jest mock returns nothing. Jest mock should also return a mocked function.

# Test plan

Dependent on existing test suite