### PR TITLE
fix: prevent typescript error for NetInfoState

### DIFF
--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -32,7 +32,7 @@ export interface NetInfoConnectedDetails {
 
 interface NetInfoConnectedState<
   T extends NetInfoStateType,
-  D extends Record<string, unknown> = Record<string, unknown>
+  D extends Record<string, unknown> = {}
 > {
   type: T;
   isConnected: true;


### PR DESCRIPTION
### Error:

```ts
          Types of property 'type' are incompatible.
            Type 'NetInfoStateType.bluetooth' is not assignable to type 'NetInfoStateType.other'.
```

### Reasoning: 

The below types call `NetInfoConnectedState` which expects 2 arguments `NetInfoConnectedState<T extends NetInfoStateType, D extends Record<string, unknown>>`. Since a second argument is never passed, Typescript is unable to distinguish between each type and thinks the `type` is incompatible. If we default the 2nd argument to an empty object `{}`, Typescript can then distinguish between each type and the error goes away.

```ts
export type NetInfoBluetoothState = NetInfoConnectedState<NetInfoStateType.bluetooth>;
export type NetInfoWimaxState = NetInfoConnectedState<NetInfoStateType.wimax>;
export type NetInfoVpnState = NetInfoConnectedState<NetInfoStateType.vpn>;
export type NetInfoOtherState = NetInfoConnectedState<NetInfoStateType.other>;
```