### PR TITLE
fix(web, isConnected): Return actual connection state even if network type is 'unknown'

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Describes the current state of the network. It is an object with these propertie
 | Property              | Type                                    | Description                                                                                        |
 | --------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | `type`                | [`NetInfoStateType`](#netinfostatetype) | The type of the current connection.                                                                |
-| `isConnected`         | `boolean`, `null`                               | If there is an active network connection. If unknown defaults to `null`. |
+| `isConnected`         | `boolean`, `null`                               | If there is an active network connection. Defaults to `null` on most platforms for `unknown` networks. Note: Web browsers report network type `unknown` for many otherwise valid networks (https://caniuse.com/netinfo), so `isConnected` may be `true` or `false` and represent a real connection status even for unknown network types in certain cases.|
 | `isInternetReachable` | `boolean`, `null`                             | If the internet is reachable with the currently active network connection. If unknown defaults to `null`                         |
 | `isWifiEnabled`       | `boolean`                               | *(Android only)* Whether the device's WiFi is ON or OFF.                                           |
 | `details`             |                                         | The value depends on the `type` value. See below.                                                  |

--- a/src/internal/nativeModule.web.ts
+++ b/src/internal/nativeModule.web.ts
@@ -213,7 +213,7 @@ const getCurrentState = (
   } else if (type === NetInfoStateType.unknown) {
     const state: NetInfoUnknownState = {
       ...baseState,
-      isConnected: null,
+      isConnected,
       isInternetReachable: null,
       type,
       details: null,

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -50,7 +50,7 @@ interface NetInfoDisconnectedState<T extends NetInfoStateType> {
 
 export interface NetInfoUnknownState {
   type: NetInfoStateType.unknown;
-  isConnected: boolean;
+  isConnected: boolean | null;
   isInternetReachable: null;
   details: null;
 }

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -50,7 +50,7 @@ interface NetInfoDisconnectedState<T extends NetInfoStateType> {
 
 export interface NetInfoUnknownState {
   type: NetInfoStateType.unknown;
-  isConnected: null;
+  isConnected: boolean;
   isInternetReachable: null;
   details: null;
 }


### PR DESCRIPTION
# Overview
Whenever connection type is 'unknown', library returns isConnected=false instead of actual connection state.  Unknown network type does not necessarily mean that we have no internet connection. For instance, Electron apps and apps running on chromebooks with instant tethering enabled return 'unknown' network type even when connected to the internet.

# Reasoning
We should return the correct connection state even for 'unknown' connection type

# Test Plan
1) Launch app on chromebook with instant tethering enabled
2) Bind change event listeners to the NetworkInformation
3) Verify that isConnected property is present in state returned from the listener and that it indicates actual network state

Fixes #450
