### PR TITLE
fix(android): try async state fetch as stale state workaround

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
@@ -29,7 +29,20 @@ import com.reactnativecommunity.netinfo.types.ConnectionType;
  */
 @TargetApi(Build.VERSION_CODES.N)
 public class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
+    private static final int DELAY_MS = 250;
     private final ConnectivityNetworkCallback mNetworkCallback;
+
+    // from the docs:
+    // "Do NOT call ConnectivityManager.getNetworkCapabilities(android.net.Network)
+    // or ConnectivityManager.getLinkProperties(android.net.Network) or other
+    // synchronous ConnectivityManager methods in this callback as this is
+    // prone to race conditions ; calling these methods while in a callback
+    // may return an outdated or even a null object."
+    // https://developer.android.com/reference/android/net/ConnectivityManager.NetworkCallback
+    // For this reason, we will fetch these values when not provided by the callback
+    // on an asynchronous thread.
+    private Network mNetwork = null;
+    private NetworkCapabilities mCapabilities = null;
 
     public NetworkCallbackConnectivityReceiver(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -60,105 +73,113 @@ public class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
 
     @SuppressLint("MissingPermission")
     void updateAndSend() {
-        // from the docs:
-        // "Do NOT call ConnectivityManager.getNetworkCapabilities(android.net.Network)
-        // or ConnectivityManager.getLinkProperties(android.net.Network) or other
-        // synchronous ConnectivityManager methods in this callback as this is
-        // prone to race conditions ; calling these methods while in a callback
-        // may return an outdated or even a null object."
-        // https://developer.android.com/reference/android/net/ConnectivityManager.NetworkCallback
+        ConnectionType connectionType = ConnectionType.UNKNOWN;
+        CellularGeneration cellularGeneration = null;
+        NetworkInfo networkInfo = null;
+        boolean isInternetReachable = false;
+        boolean isInternetSuspended = false;
+
+        if (mCapabilities != null) {
+            // Get the connection type
+            if (mCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)) {
+                connectionType = ConnectionType.BLUETOOTH;
+            } else if (mCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
+                connectionType = ConnectionType.CELLULAR;
+            } else if (mCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
+                connectionType = ConnectionType.ETHERNET;
+            } else if (mCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+                connectionType = ConnectionType.WIFI;
+            } else if (mCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
+                connectionType = ConnectionType.VPN;
+            }
+
+            if (mNetwork != null) {
+                // This may return null per API docs, and is deprecated, but for older APIs (< VERSION_CODES.P)
+                // we need it to test for suspended internet
+                networkInfo = getConnectivityManager().getNetworkInfo(mNetwork);
+            }
+
+            // Check to see if the network is temporarily unavailable or if airplane mode is toggled on
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                isInternetSuspended = !mCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_SUSPENDED);
+            } else {
+                if (mNetwork != null && networkInfo != null) {
+                    NetworkInfo.DetailedState detailedConnectionState = networkInfo.getDetailedState();
+                    if (!detailedConnectionState.equals(NetworkInfo.DetailedState.CONNECTED)) {
+                        isInternetSuspended = true;
+                    }
+                }
+            }
+
+            isInternetReachable =
+                    mCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                            && mCapabilities.hasCapability(
+                            NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+                            && !isInternetSuspended;
+
+            // Get the cellular network type
+            if (mNetwork != null && connectionType == ConnectionType.CELLULAR && isInternetReachable) {
+                cellularGeneration = CellularGeneration.fromNetworkInfo(networkInfo);
+            }
+        } else {
+            connectionType = ConnectionType.NONE;
+        }
+
+        updateConnectivity(connectionType, cellularGeneration, isInternetReachable);
+    }
+
+    private void asyncUpdateAndSend() {
         new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
             @Override
             public void run() {
-                Network network = getConnectivityManager().getActiveNetwork();
-                NetworkCapabilities capabilities = getConnectivityManager().getNetworkCapabilities(network);
-                ConnectionType connectionType = ConnectionType.UNKNOWN;
-                CellularGeneration cellularGeneration = null;
-                NetworkInfo networkInfo = null;
-                boolean isInternetReachable = false;
-                boolean isInternetSuspended = false;
+                mCapabilities = getConnectivityManager().getNetworkCapabilities(mNetwork);
+                updateAndSend();
 
-                if (capabilities != null) {
-                    // Get the connection type
-                    if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)) {
-                        connectionType = ConnectionType.BLUETOOTH;
-                    } else if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
-                        connectionType = ConnectionType.CELLULAR;
-                    } else if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
-                        connectionType = ConnectionType.ETHERNET;
-                    } else if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
-                        connectionType = ConnectionType.WIFI;
-                    } else if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
-                        connectionType = ConnectionType.VPN;
-                    }
-
-                    if (network != null) {
-                        // This may return null per API docs, and is deprecated, but for older APIs (< VERSION_CODES.P)
-                        // we need it to test for suspended internet
-                        networkInfo = getConnectivityManager().getNetworkInfo(network);
-                    }
-
-                    // Check to see if the network is temporarily unavailable or if airplane mode is toggled on
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                        isInternetSuspended = !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_SUSPENDED);
-                    } else {
-                        if (network != null && networkInfo != null) {
-                            NetworkInfo.DetailedState detailedConnectionState = networkInfo.getDetailedState();
-                            if (!detailedConnectionState.equals(NetworkInfo.DetailedState.CONNECTED)) {
-                                isInternetSuspended = true;
-                            }
-                        }
-                    }
-
-                    isInternetReachable =
-                            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-                                    && capabilities.hasCapability(
-                                    NetworkCapabilities.NET_CAPABILITY_VALIDATED)
-                                    && !isInternetSuspended;
-
-                    // Get the cellular network type
-                    if (network != null && connectionType == ConnectionType.CELLULAR && isInternetReachable) {
-                        cellularGeneration = CellularGeneration.fromNetworkInfo(networkInfo);
-                    }
-                } else {
-                    connectionType = ConnectionType.NONE;
-                }
-
-                updateConnectivity(connectionType, cellularGeneration, isInternetReachable);
             }
-        }, 200);
+        }, DELAY_MS);
     }
 
     private class ConnectivityNetworkCallback extends ConnectivityManager.NetworkCallback {
         @Override
         public void onAvailable(Network network) {
-            updateAndSend();
+            mNetwork = network;
+            asyncUpdateAndSend();
         }
 
         @Override
         public void onLosing(Network network, int maxMsToLive) {
+            mNetwork = network;
             updateAndSend();
         }
 
         @Override
         public void onLost(Network network) {
+            mNetwork = null;
+            mCapabilities = null;
             updateAndSend();
         }
 
         @Override
         public void onUnavailable() {
+            mNetwork = null;
+            mCapabilities = null;
             updateAndSend();
         }
 
         @Override
         public void onCapabilitiesChanged(
                 Network network, NetworkCapabilities networkCapabilities) {
+            mNetwork = network;
+            mCapabilities = networkCapabilities;
             updateAndSend();
         }
 
         @Override
         public void onLinkPropertiesChanged(Network network, LinkProperties linkProperties) {
-            updateAndSend();
+            if (mNetwork != null) {
+                mNetwork = network;
+            }
+            asyncUpdateAndSend();
         }
     }
 }


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Attempt to fix https://github.com/react-native-netinfo/react-native-netinfo/issues/542 and https://github.com/react-native-netinfo/react-native-netinfo/issues/537 without fully undoing https://github.com/react-native-netinfo/react-native-netinfo/pull/510 changes.

The change aims to address the issue https://github.com/react-native-netinfo/react-native-netinfo/pull/510 fixes (not calling the network methods in the callback), but preserving the original implementation that uses data from the callbacks.

Could use some review and thoughts @mikehardy and @Willham12 

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Manually tested on a Google Pixel 5 (Android 12)

Commands that helped debug:
adb shell dumpsys deviceidle force-idle
adb shell dumpsys deviceidle unforce
adb shell input keyevent KEYCODE_WAKEUP
