### PR TITLE
fix(android): avoid send event when has no listener

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -34,6 +34,7 @@ public abstract class ConnectivityReceiver {
     private final WifiManager mWifiManager;
     private final TelephonyManager mTelephonyManager;
     private final ReactApplicationContext mReactContext;
+    public boolean hasListener = false;
 
     @Nonnull
     private ConnectionType mConnectionType = ConnectionType.UNKNOWN;
@@ -96,7 +97,9 @@ public abstract class ConnectivityReceiver {
             mConnectionType = connectionType;
             mCellularGeneration = cellularGeneration;
             mIsInternetReachable = isInternetReachable;
-            sendConnectivityChangedEvent();
+            if (hasListener) {
+                sendConnectivityChangedEvent();
+            }
         }
     }
 

--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoModule.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoModule.java
@@ -43,6 +43,7 @@ public class NetInfoModule extends ReactContextBaseJavaModule implements AmazonF
     public void onCatalystInstanceDestroy() {
         mAmazonConnectivityChecker.unregister();
         mConnectivityReceiver.unregister();
+        mConnectivityReceiver.hasListener = false;
     }
 
     @Override

--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoModule.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoModule.java
@@ -63,10 +63,14 @@ public class NetInfoModule extends ReactContextBaseJavaModule implements AmazonF
     @ReactMethod
     public void addListener(String eventName) {
         // Keep: Required for RN built in Event Emitter Calls.
+        mConnectivityReceiver.hasListener = true;
     }
 
     @ReactMethod
     public void removeListeners(Integer count) {
         // Keep: Required for RN built in Event Emitter Calls.
+        if (count == 0) {
+            mConnectivityReceiver.hasListener = false;
+        }
     }
 }


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
This commit just make sure that module will not  read MAC info before add listener for it.
Everytime createConnectivityEventMap method called when send event, it will get wifiinfo.
It's illegal in China when app read MAC info before user agree the privacy agreement.

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
