### PR TITLE
fix: android: make sure initial network value is not stale on app startup

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
@@ -79,31 +79,34 @@ public class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
         boolean isInternetReachable = false;
         boolean isInternetSuspended = false;
 
-        if (mCapabilities != null) {
+        final Network network = mNetwork;
+        final NetworkCapabilities capabilities = mCapabilities;
+
+        if (capabilities != null) {
             // Get the connection type
-            if (mCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)) {
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)) {
                 connectionType = ConnectionType.BLUETOOTH;
-            } else if (mCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
+            } else if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
                 connectionType = ConnectionType.CELLULAR;
-            } else if (mCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
+            } else if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
                 connectionType = ConnectionType.ETHERNET;
-            } else if (mCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+            } else if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
                 connectionType = ConnectionType.WIFI;
-            } else if (mCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
+            } else if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
                 connectionType = ConnectionType.VPN;
             }
 
-            if (mNetwork != null) {
+            if (network != null) {
                 // This may return null per API docs, and is deprecated, but for older APIs (< VERSION_CODES.P)
                 // we need it to test for suspended internet
-                networkInfo = getConnectivityManager().getNetworkInfo(mNetwork);
+                networkInfo = getConnectivityManager().getNetworkInfo(network);
             }
 
             // Check to see if the network is temporarily unavailable or if airplane mode is toggled on
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                isInternetSuspended = !mCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_SUSPENDED);
+                isInternetSuspended = !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_SUSPENDED);
             } else {
-                if (mNetwork != null && networkInfo != null) {
+                if (network != null && networkInfo != null) {
                     NetworkInfo.DetailedState detailedConnectionState = networkInfo.getDetailedState();
                     if (!detailedConnectionState.equals(NetworkInfo.DetailedState.CONNECTED)) {
                         isInternetSuspended = true;
@@ -112,13 +115,13 @@ public class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
             }
 
             isInternetReachable =
-                    mCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-                            && mCapabilities.hasCapability(
+                    capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                            && capabilities.hasCapability(
                             NetworkCapabilities.NET_CAPABILITY_VALIDATED)
                             && !isInternetSuspended;
 
             // Get the cellular network type
-            if (mNetwork != null && connectionType == ConnectionType.CELLULAR && isInternetReachable) {
+            if (network != null && connectionType == ConnectionType.CELLULAR && isInternetReachable) {
                 cellularGeneration = CellularGeneration.fromNetworkInfo(networkInfo);
             }
         } else {


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
When the app is started with no connectivity (e.g., wifi off or airplane mode), the library currently reports `unknown` and `connected = true` values because network listeners are never called when there's no network info, so all default values are read.

After this, we now try to properly set the initial network values on register (similar to what the old broadcast received does and was not carried over to the new implementation.

I've also taken the chance to replace the `Runnable` with a lambda as suggested by the linter.

P.S.: no idea why old commits were carried over, I'm sure I branched from master.

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Tested on Google Pixel 5 (Android 12, RN 0.66.3)

Steps to test:
- Turn airplane mode on
- Open the app (cold start, no previously stored states)
- Check results of `NetInfo.fetch()` on mount or similar, type should be `none`
- Turn off airplane mode, and make sure connectivity is reported correctly.

Test again, but now without airplane mode on startup, to make sure the app still reports connectivity when first started if available.


