### PR TITLE
android added correct listeners counting

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoModule.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoModule.java
@@ -21,6 +21,8 @@ public class NetInfoModule extends ReactContextBaseJavaModule implements AmazonF
     private final ConnectivityReceiver mConnectivityReceiver;
     private final AmazonFireDeviceConnectivityPoller mAmazonConnectivityChecker;
 
+    private int numberOfListeners = 0;
+
     public NetInfoModule(ReactApplicationContext reactContext) {
         super(reactContext);
         // Create the connectivity receiver based on the API level we are running on
@@ -63,14 +65,14 @@ public class NetInfoModule extends ReactContextBaseJavaModule implements AmazonF
 
     @ReactMethod
     public void addListener(String eventName) {
-        // Keep: Required for RN built in Event Emitter Calls.
+        numberOfListeners++;
         mConnectivityReceiver.hasListener = true;
     }
 
     @ReactMethod
     public void removeListeners(Integer count) {
-        // Keep: Required for RN built in Event Emitter Calls.
-        if (count == 0) {
+        numberOfListeners -= count;
+        if (numberOfListeners == 0) {
             mConnectivityReceiver.hasListener = false;
         }
     }


### PR DESCRIPTION
# Overview
Fixes #567


# Test Plan
The changed behavior is not observable, unless you watch the events send over the RN bridge

Note:
It would be better to also remove the android network listeners if there are no listeners in RN. I also develop other RN modules and there we use kotlin, coroutines and flows which allows us to implement RN modules in a reactive way without the overhead of managing threads, subscriptions, events and callbacks.
