### PR TITLE
Airplane mode bug [Android]

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
@@ -13,7 +13,6 @@ import android.net.LinkProperties;
 import android.net.Network;
 import android.net.NetworkCapabilities;
 import android.net.NetworkInfo;
-import android.net.NetworkRequest;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
@@ -53,8 +52,6 @@ public class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
     @SuppressLint("MissingPermission")
     public void register() {
         try {
-            NetworkRequest.Builder builder = new NetworkRequest.Builder();
-
             // Similar to BroadcastReceiver implementation, we need to force
             // an initial callback call in order to get the current network state,
             // otherwise, an app started without any network connection will
@@ -62,7 +59,7 @@ public class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
             mNetwork = getConnectivityManager().getActiveNetwork();
             asyncUpdateAndSend(0);
 
-            getConnectivityManager().registerNetworkCallback(builder.build(), mNetworkCallback);
+            getConnectivityManager().registerDefaultNetworkCallback(mNetworkCallback);
         } catch (SecurityException e) {
             // TODO: Display a yellow box about this
         }


### PR DESCRIPTION

Addressing issue #554

# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
It was noticed that Android 7 and up when ever the devices airplane mode was enabled then disabled the `isConnected` value would be false even though internet was present. This only happened when the device has both Wifi and LTE enabled and came out of airplane mode. 

After looking into the [onLost](https://developer.android.com/reference/android/net/ConnectivityManager.NetworkCallback#onLosing(android.net.Network,%20int)) method, I switch over to using [registerDefaultNetworkCallback](https://developer.android.com/reference/android/net/ConnectivityManager#registerDefaultNetworkCallback(android.net.ConnectivityManager.NetworkCallback)) for the callback register. This prevent the `onLost` methods from being fired when there was Network access from at least on off the connection i.e. Wifi/LTE.

Let me know what you guys think.


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Not sure if this counts. But using the example Android app the changes were verified by running over the scenario described above.