### PR TITLE
#315 Fix TypeError: fetch is not a function

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@typescript-eslint/eslint-plugin": "^4.32.0",
     "@typescript-eslint/parser": "^4.32.0",
     "babel-loader": "^8.0.6",
+    "cross-fetch": "^3.1.5"
     "eslint": "7.31.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-prettier": "3.1.2",

--- a/src/internal/internetReachability.ts
+++ b/src/internal/internetReachability.ts
@@ -9,6 +9,7 @@
 
 import * as Types from './types';
 import * as PrivateTypes from './privateTypes';
+import fetch from 'cross-fetch';
 
 interface InternetReachabilityCheckHandler {
   promise: Promise<void>;


### PR DESCRIPTION
Import fetch inside the file to fix issue #315

# Overview

Fix fetch is not a function on iOS 15


# Test Plan
Nothing needed, as there is no change on functionality; just add extra import to cross-fetch
