### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ const YourComponent = () => {
   return (
     <View>
       <Text>Type: {netInfo.type}</Text>
-      <Text>Is Connected? {netInfo.isConnected.toString()}</Text>
+      <Text>Is Connected? {netInfo.isConnected?.toString()}</Text>
     </View>
   );
 };


### PR DESCRIPTION

# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Adding optional chaining as isConnected may be null causing an error:
>Uncaught TypeError: Cannot read properties of null (reading 'toString')
