### PR TITLE
feat: add imperative api to refresh state

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ NetInfo.fetch().then(state => {
   * [`NetInfoCellularGeneration`](#netinfocellulargeneration)
 * **Methods:**
   * [`fetch()`](#fetch)
+  * [`refresh()`](#refresh)
   * [`addEventListener()`](#addeventlistener)
   * [`useNetInfo()`](#usenetinfo)
 
@@ -344,6 +345,20 @@ NetInfo.fetch("wifi").then(state => {
   console.log("Is connected?", state.isConnected);
 });
 ```
+
+#### `refresh()`
+
+Updates NetInfo's internal state, then returns a `Promise` that resolves to a [`NetInfoState`](#netinfostate) object. This is similar to `fetch()`, but really only useful on platforms that do not supply internet reachability natively. For example, you can use it to immediately re-run an internet reachability test if a network request fails unexpectedly.
+
+**Example:**
+```javascript
+NetInfo.refresh().then(state => {
+    console.log("Connection type", state.type);
+    console.log("Is connected?", state.isConnected);
+});
+```
+
+This will also update subscribers using `addEventListener` and/or `useNetInfo`.
 
 ## Troubleshooting
 

--- a/example/ConnectionInfoRefresh.tsx
+++ b/example/ConnectionInfoRefresh.tsx
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import {Text, View, TouchableOpacity} from 'react-native';
+import NetInfo from '../src';
+
+interface State {
+  connectionInfo: string;
+}
+
+export default class ConnectionInfoCurrent extends React.Component<
+  Record<string, unknown>,
+  State
+> {
+  state = {
+    connectionInfo: 'Tap to refresh state',
+  };
+
+  componentDidMount(): void {
+    this._refreshState();
+  }
+
+  _refreshState = async (): Promise<void> => {
+    const state = await NetInfo.refresh();
+    this.setState({
+      connectionInfo: JSON.stringify(state),
+    });
+  };
+
+  render() {
+    return (
+      <View>
+        <TouchableOpacity onPress={this._refreshState}>
+          <Text style={{color: 'black'}}>{this.state.connectionInfo}</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+}

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -23,6 +23,7 @@ import {
 import ConnectionInfoSubscription from './ConnectionInfoSubscription';
 import ConnectionInfoCurrent from './ConnectionInfoCurrent';
 import ConnectionInfoFetch from './ConnectionInfoFetch';
+import ConnectionInfoRefresh from './ConnectionInfoRefresh';
 import NetInfoHook from './NetInfoHook';
 import IsConnected from './IsConnected';
 
@@ -49,6 +50,14 @@ const EXAMPLES: Example[] = [
     description: 'Fetch the state on tap',
     render() {
       return <ConnectionInfoFetch />;
+    },
+  },
+  {
+    id: 'refresh',
+    title: 'NetInfo.refresh',
+    description: 'Refresh the state on tap',
+    render() {
+      return <ConnectionInfoRefresh />;
     },
   },
   {

--- a/jest/netinfo-mock.js
+++ b/jest/netinfo-mock.js
@@ -16,11 +16,13 @@ const defaultState = {
 const RNCNetInfoMock = {
   configure: jest.fn(),
   fetch: jest.fn(),
+  refresh: jest.fn(),
   addEventListener: jest.fn(),
   useNetInfo: jest.fn(),
 };
 
 RNCNetInfoMock.fetch.mockResolvedValue(defaultState);
+RNCNetInfoMock.refresh.mockResolvedValue(defaultState);
 RNCNetInfoMock.useNetInfo.mockReturnValue(defaultState);
 RNCNetInfoMock.addEventListener.mockReturnValue(jest.fn());
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,18 @@ export function fetch(
 }
 
 /**
+ * Force-refreshes the internal state of the NetInfo library.
+ *
+ * @returns A Promise which contains the updated connection state.
+ */
+export function refresh(): Promise<Types.NetInfoState> {
+  if (!_state) {
+    _state = createState();
+  }
+  return _state._fetchCurrentState();
+}
+
+/**
  * Subscribe to connection information. The callback is called with a parameter of type
  * [`NetInfoState`](README.md#netinfostate) whenever the connection state changes. Your listener
  * will be called with the latest information soon after you subscribe and then with any

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,7 @@ export * from './internal/types';
 export default {
   configure,
   fetch,
+  refresh,
   addEventListener,
   useNetInfo,
 };

--- a/src/internal/state.ts
+++ b/src/internal/state.ts
@@ -65,7 +65,7 @@ export default class State {
     this._subscriptions.forEach((handler): void => handler(nextState));
   };
 
-  private _fetchCurrentState = async (
+  public _fetchCurrentState = async (
     requestedInterface?: string,
   ): Promise<Types.NetInfoState> => {
     const state = await NativeInterface.getCurrentState(requestedInterface);


### PR DESCRIPTION
Fixes https://github.com/react-native-netinfo/react-native-netinfo/issues/593

# Overview
This pull request implements a new imperative API called `refresh` to update NetInfo's state by forcing the native interface to recompute the library's internal state. More detailed in the [linked issue](https://github.com/react-native-netinfo/react-native-netinfo/issues/593) 🙂 

# Test Plan
Keeping the tests pretty simple for now:

1. Run `yarn start:web` to run the example web app.
1. Open and clear the network console.
1. Tap on `NetInfo.fetch` – observe that no network request is made to retest internet reachability.
1. Tap on `NetInfo.refresh` – observe that a network request is made to retest internet reachability.

There's certainly more that could be done to test this, but personally this is enough to make me confident that this is working as expected.

https://user-images.githubusercontent.com/47436092/161911879-fe0d5078-af31-4675-a316-c320a7ffda87.mov
