### PR TITLE
fix(windows)!: change WindowsTargetPlatformVersion to 10.0 / drop arm32 / drop rnw < 0.63

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,30 +61,14 @@ Linking the package manually is not required anymore with [Autolinking](https://
 
 - **Windows Platform:**
 
-  Autolinking works on RNW >= 0.63. If you need to manually link, see the [Manual linking steps for Windows](#manual-linking-windows) below.
+  Autolinking automatically works on RNW >= 0.63.
 
-<details id='manual-linking-windows'>
-<summary>Manually link the library on Windows</summary>
+## Minimum supported versions for windows
 
-#### Link to your C++ app (RNW >= 0.62)
-* Open the solution in Visual Studio for your Windows apps
-* Right click in the Explorer and click Add > Existing Project...
-* Navigate to `./<app-name>/node_modules/@react-native-community/netinfo/windows/RNCNetInfoCPP/` and add `RNCNetInfoCPP.vcxproj`
-* This time right click on your React Native Windows app under your solutions directory and click Add > Reference...
-* Check the `RNCNetInfoCPP` you just added and press ok
-* Open `pch.h`, add `#include "winrt/ReactNativeNetInfo.h"`
-* Open `App.cpp`, add `PackageProviders().Append(winrt::ReactNativeNetInfo::ReactPackageProvider());` before `InitializeComponent();`
+- react-native-windows 0.63 or newer
+- MSVC build tools v142 (included in Visual Studio 2019) or newer
+- x86, x64, or arm64 are supported, arm (32-bit) is not supported
 
-#### Link C# to your C# app (RNW >= 0.62)
-* Open the solution in Visual Studio for your Windows apps
-* Right click in the Explorer and click Add > Existing Project...
-* Navigate to `./<app-name>/node_modules/@react-native-community/netinfo/windows/RNCNetInfoCPP/` and add `RNCNetInfoCPP.vcxproj`
-* This time right click on your React Native Windows app under your solutions directory and click Add > Reference...
-* Check the `RNCNetInfoCPP` you just added and press ok
-* Open up `App.xaml.cs` for your app and add `using ReactNativeNetInfo;` to the top.
-* Open up `App.xaml.cs` for your app and add `PackageProviders.Add(new ReactNativeNetInfo.ReactPackageProvider());` before `InitializeComponent();`
-
-</details>
 
 ## React Native Compatibility
 To use this library you need to ensure you are using the correct version of React Native.

--- a/windows/RNCNetInfoCPP/RNCNetInfoCPP.vcxproj
+++ b/windows/RNCNetInfoCPP/RNCNetInfoCPP.vcxproj
@@ -14,7 +14,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/windows/RNCNetInfoCPP/RNCNetInfoCPP.vcxproj
+++ b/windows/RNCNetInfoCPP/RNCNetInfoCPP.vcxproj
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="16.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(SolutionDir)\ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)\ExperimentalFeatures.props')" />
-  <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
@@ -22,14 +21,6 @@
     <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|ARM">
-      <Configuration>Debug</Configuration>
-      <Platform>ARM</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|ARM">
-      <Configuration>Release</Configuration>
-      <Platform>ARM</Platform>
-    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|ARM64">
       <Configuration>Debug</Configuration>
       <Platform>ARM64</Platform>
@@ -146,13 +137,13 @@
     <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.targets'))" />
   </Target>
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>
 </Project>

--- a/windows/RNCNetInfoCPP/packages.config
+++ b/windows/RNCNetInfoCPP/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.200316.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
 </packages>


### PR DESCRIPTION
# Overview

Changed to general version for WindowsTargetPlatformVersion

Using an explicit version of WindowsTargetPlatformVersion requires that specific windows SDK version to be installed on the machine.
In Visual Studio 2017 (version 15 or build tools 141) and earlier it was required but as of Visual Studio 2019 (v16 or v142) and Visual Studio 2022(v17 or v143) you can simply specify "10.0". This allows a lot more flexibility to the developer or build machine as there is a growing number of different windows 10 SDK out there now.


# Test Plan
You can now install/run on machines without needing as specific of a windows 10.0 version (think of this as saying using the latest version of windows 10 sdk you have installed, so long as it meets the WindowsTargetPlatformMinVersion.

Newer versions of azure hosted windows images have a different subset.

VS2022 Azure Window image has
10.0.17763.0, 10.0.19041.0, 10.0.20348.0, 10.0.22000.0
VS2019 Azure Window image had
10.0.14393.0, 10.0.16299.0, 10.0.17134.0, 10.0.17763.0, 10.0.18362.0, 10.0.19041.0, 10.0.20348.0, 10.0.22000.0