### PR TITLE
feat: add parameter useNativeReachability to optionally choose non-native reachability test

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,13 +220,14 @@ The configuration options for the library.
 
 | Property | Type | Default | Description
 | ---------------------------- | --------------------------------- | ----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | 
-| `reachabilityUrl`            | `string`                          | `https://clients3.google.com/generate_204` | The URL to call to test if the internet is reachable. Only used on platforms which do not supply internet reachability natively.                                                                                                          |
-| `reachabilityTest`           | `(response: Response) => boolean` | `Promise.resolve(response.status === 204)` | A function which is passed the `Response` from calling the reachability URL. It should return `true` if the response indicates that the internet is reachable. Only used on platforms which do not supply internet reachability natively. |
-| `reachabilityShortTimeout`   | `number`                          | 5 seconds | The number of milliseconds between internet reachability checks when the internet was not previously detected. Only used on platforms which do not supply internet reachability natively.                                                 |
-| `reachabilityLongTimeout`    | `number`                          | 60 seconds | The number of milliseconds between internet reachability checks when the internet was previously detected. Only used on platforms which do not supply internet reachability natively.                                                     |
-| `reachabilityRequestTimeout` | `number`                          | 15 seconds | The number of milliseconds that a reachability check is allowed to take before failing. Only used on platforms which do not supply internet reachability natively.                                                   |                    
+| `reachabilityUrl`            | `string`                          | `https://clients3.google.com/generate_204` | The URL to call to test if the internet is reachable. Only used on platforms which do not supply internet reachability natively or if `useNativeReachability` is `false`.                                                                                                          |
+| `reachabilityTest`           | `(response: Response) => boolean` | `Promise.resolve(response.status === 204)` | A function which is passed the `Response` from calling the reachability URL. It should return `true` if the response indicates that the internet is reachable. Only used on platforms which do not supply internet reachability natively or if `useNativeReachability` is `false`. |
+| `reachabilityShortTimeout`   | `number`                          | 5 seconds | The number of milliseconds between internet reachability checks when the internet was not previously detected. Only used on platforms which do not supply internet reachability natively or if `useNativeReachability` is `false`.                                                 |
+| `reachabilityLongTimeout`    | `number`                          | 60 seconds | The number of milliseconds between internet reachability checks when the internet was previously detected. Only used on platforms which do not supply internet reachability natively or if `useNativeReachability` is `false`.                                                     |
+| `reachabilityRequestTimeout` | `number`                          | 15 seconds | The number of milliseconds that a reachability check is allowed to take before failing. Only used on platforms which do not supply internet reachability natively or if `useNativeReachability` is `false`.                                                   |                    
 | `reachabilityShouldRun` | `() => boolean`                          | `() => true` | A function which returns a boolean to determine if checkInternetReachability should be run.                                                   |                    
 | `shouldFetchWiFiSSID` | `boolean`                          | `false` | A flag indicating one of the requirements on iOS has been met to retrieve the network (B)SSID, and the native SSID retrieval APIs should be called.  This has no effect on Android.
+| `useNativeReachability` | `boolean`                          | `true` | A flag indicating whether or not Netinfo should use native reachability checks, if available. 
 
 
 ### Methods
@@ -246,7 +247,8 @@ NetInfo.configure({
   reachabilityShortTimeout: 5 * 1000, // 5s
   reachabilityRequestTimeout: 15 * 1000, // 15s
   reachabilityShouldRun: () => true,
-  shouldFetchWiFiSSID: true // met iOS requirements to get SSID. Will leak memory if set to true without meeting requirements.
+  shouldFetchWiFiSSID: true, // met iOS requirements to get SSID. Will leak memory if set to true without meeting requirements.
+  useNativeReachability: false
 });
 ```
 
@@ -301,7 +303,8 @@ const YourComponent = () => {
     reachabilityShortTimeout: 5 * 1000, // 5s
     reachabilityRequestTimeout: 15 * 1000, // 15s
     reachabilityShouldRun: () => true,
-    shouldFetchWiFiSSID: true // met iOS requirements to get SSID
+    shouldFetchWiFiSSID: true, // met iOS requirements to get SSID
+    useNativeReachability: false
   });
 
   // ...

--- a/src/internal/defaultConfiguration.ts
+++ b/src/internal/defaultConfiguration.ts
@@ -8,7 +8,8 @@ const DEFAULT_CONFIGURATION: Types.NetInfoConfiguration = {
   reachabilityLongTimeout: 60 * 1000, // 60s
   reachabilityRequestTimeout: 15 * 1000, // 15s
   reachabilityShouldRun: (): boolean => true,
-  shouldFetchWiFiSSID: false
+  shouldFetchWiFiSSID: false,
+  useNativeReachability: true
 };
 
 export default DEFAULT_CONFIGURATION;

--- a/src/internal/defaultConfiguration.web.ts
+++ b/src/internal/defaultConfiguration.web.ts
@@ -8,7 +8,8 @@ const DEFAULT_CONFIGURATION: Types.NetInfoConfiguration = {
   reachabilityLongTimeout: 60 * 1000, // 60s
   reachabilityRequestTimeout: 15 * 1000, // 15s
   reachabilityShouldRun: (): boolean => true,
-  shouldFetchWiFiSSID: true
+  shouldFetchWiFiSSID: true,
+  useNativeReachability: true
 };
 
 export default DEFAULT_CONFIGURATION

--- a/src/internal/internetReachability.ts
+++ b/src/internal/internetReachability.ts
@@ -144,7 +144,10 @@ export default class InternetReachability {
   };
 
   public update = (state: PrivateTypes.NetInfoNativeModuleState): void => {
-    if (typeof state.isInternetReachable === 'boolean' && this._configuration.useNativeReachability) {
+    if (
+      typeof state.isInternetReachable === 'boolean' &&
+      this._configuration.useNativeReachability
+    ) {
       this._setIsInternetReachable(state.isInternetReachable);
     } else {
       this._setExpectsConnection(state.isConnected);

--- a/src/internal/internetReachability.ts
+++ b/src/internal/internetReachability.ts
@@ -144,7 +144,7 @@ export default class InternetReachability {
   };
 
   public update = (state: PrivateTypes.NetInfoNativeModuleState): void => {
-    if (typeof state.isInternetReachable === 'boolean') {
+    if (typeof state.isInternetReachable === 'boolean' && this._configuration.useNativeReachability) {
       this._setIsInternetReachable(state.isInternetReachable);
     } else {
       this._setExpectsConnection(state.isConnected);

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -115,4 +115,5 @@ export interface NetInfoConfiguration {
   reachabilityRequestTimeout: number;
   reachabilityShouldRun: () => boolean;
   shouldFetchWiFiSSID: boolean;
+  useNativeReachability: boolean;
 }


### PR DESCRIPTION
# Overview
While using the API, the reachability checks for some Android devices, namely Amazon Kindle Fires, weren't entirely reliable. Upon testing a case where I manually pulled the plug on the internet, the `isInternetReachable` would still return `true` for minutes without an update. The non-native implementation for reachability checks for iOS works very well, so I'm proposing a solution where the user can specify a param to utilize the custom reachability checks to bypass this issue (or if for whatever other reason, they want to specify custom reachability parameters). 

# Test Plan
 * Ran `yarn start:android` and built to Amazon Fire Kindle. Accurately reported Network changes
![image](https://user-images.githubusercontent.com/5956893/175434133-4733d49b-7108-46bb-957a-dcc263b1d441.png)
 * Tests passed:
![image](https://user-images.githubusercontent.com/5956893/175434259-4d1466b8-ea7b-41d7-8f05-0110835243be.png)
