### PR TITLE
Remove androidXCore requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Linking the package manually is not required anymore with [Autolinking](https://
       minSdkVersion = xyz
       compileSdkVersion = xyz
       targetSdkVersion = xyz
-      androidXCore = "1.7.0" // <-- Add this. Check versions here: https://developer.android.com/jetpack/androidx/releases/core
     }
   ```
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -7,8 +7,6 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 30
         targetSdkVersion = 30
-        androidXVersion = "1.+" // Default AndroidX dependency
-        androidXCore = "1.0.2"
 
         // e2e
         kotlinVersion = '1.5.10'


### PR DESCRIPTION
`androidXCore` is no longer required as it's not used anywhere in the project.
AndroidX dependency was dropped in https://github.com/react-native-netinfo/react-native-netinfo/commit/2569f56