### PR TITLE
fix: allow mocking netinfostate type for testing

### DIFF
--- a/jest/netinfo-mock.js
+++ b/jest/netinfo-mock.js
@@ -13,7 +13,21 @@ const defaultState = {
   },
 };
 
+const NetInfoStateType = {
+  unknown: "unknown",
+  none: "none",
+  cellular: "cellular",
+  wifi: "wifi",
+  bluetooth: "bluetooth",
+  ethernet: "ethernet",
+  wimax: "wimax",
+  vpn: "vpn",
+  other: "other",
+};
+
+
 const RNCNetInfoMock = {
+  NetInfoStateType,
   configure: jest.fn(),
   fetch: jest.fn(),
   refresh: jest.fn(),


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
This pull request allows mocking `NetInfoStateType`. And resolves the error below when testing any component uses `NetInfoStateType`.

![netinfo](https://user-images.githubusercontent.com/61876765/184633279-51bcf38c-af3e-4771-a5af-aba1c4aed135.png)


# Test Plan


<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
