### PR TITLE
fix(mac-catalyst): add check for mac catalyst target to support the platform

### DIFF
--- a/ios/RNCConnectionState.m
+++ b/ios/RNCConnectionState.m
@@ -6,11 +6,11 @@
  */
 
 #import "RNCConnectionState.h"
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_MACCATALYST
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #endif
 
-#if TARGET_OS_TV || TARGET_OS_OSX
+#if TARGET_OS_TV || TARGET_OS_OSX || TARGET_OS_MACCATALYST
 #include <ifaddrs.h>
 #endif
 
@@ -36,16 +36,16 @@
         _type = RNCConnectionTypeUnknown;
         _cellularGeneration = nil;
         _expensive = false;
-        
+
         if ((flags & kSCNetworkReachabilityFlagsReachable) == 0 ||
             (flags & kSCNetworkReachabilityFlagsConnectionRequired) != 0) {
             _type = RNCConnectionTypeNone;
         }
-#if !TARGET_OS_TV && !TARGET_OS_OSX
+#if !TARGET_OS_TV && !TARGET_OS_OSX && !TARGET_OS_MACCATALYST
         else if ((flags & kSCNetworkReachabilityFlagsIsWWAN) != 0) {
             _type = RNCConnectionTypeCellular;
             _expensive = true;
-            
+
             CTTelephonyNetworkInfo *netinfo = [[CTTelephonyNetworkInfo alloc] init];
             if (netinfo) {
                 if ([netinfo.currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyGPRS] ||
@@ -73,7 +73,7 @@
 #endif
         else {
             _type = RNCConnectionTypeWifi;
-#if TARGET_OS_TV || TARGET_OS_OSX
+#if TARGET_OS_TV || TARGET_OS_OSX || TARGET_OS_MACCATALYST
             struct ifaddrs *interfaces = NULL;
             struct ifaddrs *temp_addr = NULL;
             int success = 0;

--- a/ios/RNCNetInfo.m
+++ b/ios/RNCNetInfo.m
@@ -11,7 +11,7 @@
 #include <ifaddrs.h>
 #include <arpa/inet.h>
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_MACCATALYST
 #import <CoreTelephony/CTCarrier.h>
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #endif
@@ -130,7 +130,7 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)config)
   } else if ([requestedInterface isEqualToString: RNCConnectionTypeWifi] || [requestedInterface isEqualToString: RNCConnectionTypeEthernet]) {
     details[@"ipAddress"] = [self ipAddress] ?: NSNull.null;
     details[@"subnet"] = [self subnet] ?: NSNull.null;
-    #if !TARGET_OS_TV && !TARGET_OS_OSX   
+    #if !TARGET_OS_TV && !TARGET_OS_OSX && !TARGET_OS_MACCATALYST
       /*
         Without one of the conditions needed to use CNCopyCurrentNetworkInfo, it will leak memory.
         Clients should only set the shouldFetchWiFiSSID to true after ensuring requirements are met to get (B)SSID.
@@ -146,7 +146,7 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)config)
 
 - (NSString *)carrier
 {
-#if (TARGET_OS_TV || TARGET_OS_OSX)
+#if (TARGET_OS_TV || TARGET_OS_OSX || TARGET_OS_MACCATALYST)
   return nil;
 #else
   CTTelephonyNetworkInfo *netinfo = [[CTTelephonyNetworkInfo alloc] init];
@@ -227,7 +227,7 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)config)
   return subnet;
 }
 
-#if !TARGET_OS_TV && !TARGET_OS_OSX
+#if !TARGET_OS_TV && !TARGET_OS_OSX && !TARGET_OS_MACCATALYST
 - (NSString *)ssid
 {
   NSArray *interfaceNames = CFBridgingRelease(CNCopySupportedInterfaces());


### PR DESCRIPTION
# Overview
There have been some issues and PRs on Mac Catalyst support like #392, #412, and #415, and #415 specifically supposed to have added the support, but I was still getting compilation errors like what @giona69 posted in https://github.com/react-native-netinfo/react-native-netinfo/issues/392#issuecomment-803315982.

For each `#if` platform check in `ios/RNCNetInfo.m` and `ios/RNCConnectionState.m`, I also added another condition for `TARGET_OS_MACCATALYST` similar to what was proposed in #412 and now everything compiles and runs.

I have little experience with Objective-C or macOS development, and I have no idea why `CoreTelephony` was not compiling, but the existing implementation with `ifaddrs.h` seems to work perfectly fine for Mac Catalyst.


# Test Plan
I modified the `node_modules/@react-native-community/netinfo/ios` source code under my React Native project with my fixes and it now runs perfectly fine. `useNetInfo` is returning updated information when I disconnect or reconnect to internet.
