### PR TITLE
notify subscriptions after refresh

### DIFF
--- a/src/internal/state.ts
+++ b/src/internal/state.ts
@@ -76,6 +76,7 @@ export default class State {
     const convertedState = this._convertState(state);
     if (!requestedInterface) {
       this._latestState = convertedState;
+      this._subscriptions.forEach((handler): void => handler(convertedState));
     }
 
     return convertedState;


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Related to #591 #557

I've experienced problems with useNetInfo and location permissions. I'm using Android 11 and my app only has location permissions when the app is in foreground.

If the network changes while the app is in background bssid and ssid values are not being reported (or obfuscated). When the app comes back to foreground, no events are being triggered.

To handle that case, I've triggered `NetInfo.refresh()` when the appState becomes active again. However, this doesn't update the useNetInfo state. To force the update, I've added the event dispatch after updating _lastState.


# Test Plan

1. Run on a phone with Android 11 (10 I think is the same thing).


2. Add this code to see updates to netInfo.
```js
const netInfo = useNetInfo();
useEffect(() => {
  console.log('net info ssid is updated', netInfo?.details?.ssid) 
  

}, [netInfo?.details?.ssid])
```

3. Go to settings and change to another wifi network and wait around 10 seconds.

4. Net info ssid is updated with null

5. Go back to the app: No changes are triggered.

6. Add:

```js 
  const appState = useAppState();
  useEffect(() => {
    if (appState === 'active') {
      NetInfo.refresh();
    }
  }, [appState]);
```

With this code and my changes after coming back to the app, the ssid and bssid are updated.


### Details

 "@react-native-community/netinfo@": "9.3.2"
react-native: 0.67.3

SO Android 11.