### PR TITLE
fix(windows): fix crash in getIpAddressSync

### DIFF
--- a/windows/RNCNetInfoCPP/RNCNetInfo.cpp
+++ b/windows/RNCNetInfoCPP/RNCNetInfo.cpp
@@ -107,24 +107,30 @@ namespace winrt::ReactNativeNetInfo::implementation {
 
     std::string getIpAddressSync() noexcept
     {
-      auto icp = Windows::Networking::Connectivity::NetworkInformation::GetInternetConnectionProfile();
-      if (!icp || !icp.NetworkAdapter())
-      {
-        return "unknown";
-      } else
-      {
-        auto hostnames = Windows::Networking::Connectivity::NetworkInformation::GetHostNames();
-        for (auto const& hostname : hostnames)
+      try {
+        auto icp = Windows::Networking::Connectivity::NetworkInformation::GetInternetConnectionProfile();
+        if (!icp || !icp.NetworkAdapter())
         {
-          if (
-            hostname.Type() == Windows::Networking::HostNameType::Ipv4 &&
-            hostname.IPInformation() &&
-            hostname.IPInformation().NetworkAdapter() &&
-            hostname.IPInformation().NetworkAdapter().NetworkAdapterId() == icp.NetworkAdapter().NetworkAdapterId())
-          {
-            return winrt::to_string(hostname.CanonicalName());
-          }
+          return "unknown";
         }
+        else
+        {
+          auto hostnames = Windows::Networking::Connectivity::NetworkInformation::GetHostNames();
+          for (auto const& hostname : hostnames)
+          {
+            if (
+              hostname.Type() == Windows::Networking::HostNameType::Ipv4 &&
+              hostname.IPInformation() &&
+              hostname.IPInformation().NetworkAdapter() &&
+              hostname.IPInformation().NetworkAdapter().NetworkAdapterId() == icp.NetworkAdapter().NetworkAdapterId())
+            {
+              return winrt::to_string(hostname.CanonicalName());
+            }
+          }
+          return "unknown";
+        }
+      }
+      catch (...) {
         return "unknown";
       }
     }


### PR DESCRIPTION
# Overview
Even if not properly documented, some properties of `windows.networking.connectivity.connectionprofile` can throw. It's the case of `NetworkAdapter` since it's then calling `check_hresult` which will throw if the returned hresult is an error one.

Since `RNCNetInfo::getIpAddressSync` is marked as `noexcept`, any exception thrown in this method will call `std::terminate`.

This commit is to return `"unknown"` in this case.

# Test Plan
Unfortunately, I wasn't able to reproduce the crash some of our users face myself so I can't validate it fixes it.
Though I imported these changes in our own RN Windows project and made sure IP info is still working in the general case!


For reference, here is the stack trace we get in our crash reporting system:
RNCNetInfoCPP!__GSHandlerCheck_EH4+0x64 [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\gs\amd64\gshandlereh4.cpp @ 86]
RNCNetInfoCPP!winrt::throw_hresult+0x200 [node_modules\@react-native-community\netinfo\windows\RNCNetInfoCPP\Generated Files\winrt\base.h @ 4688]
RNCNetInfoCPP!winrt::check_hresult+0x448 [node_modules\@react-native-community\netinfo\windows\RNCNetInfoCPP\RNCNetInfo.cpp @ 111] [inlined in RNCNetInfoCPP!winrt::ReactNativeNetInfo::implementation::getIpAddressSync+0x4a0 [node_modules\@react-native-community\netinfo\windows\RNCNetInfoCPP\RNCNetInfo.cpp @ 111]]
RNCNetInfoCPP!winrt::ReactNativeNetInfo::implementation::RNCNetInfo::GetNetworkStatus$_ResumeCoro$1+0x75c [node_modules\@react-native-community\netinfo\windows\RNCNetInfoCPP\RNCNetInfo.cpp @ 191]
RNCNetInfoCPP!winrt::ReactNativeNetInfo::implementation::RNCNetInfo::GetNetworkStatus$_InitCoro$2+0x194 [node_modules\@react-native-community\netinfo\windows\RNCNetInfoCPP\RNCNetInfo.cpp @ 15732480]
RNCNetInfoCPP!winrt::ReactNativeNetInfo::implementation::RNCNetInfo::GetNetworkStatus+0x44 [node_modules\@react-native-community\netinfo\windows\RNCNetInfoCPP\RNCNetInfo.cpp @ 15732480]
RNCNetInfoCPP!<lambda_07af3bc3acbb5d7aa0533ab2f666cdc6>::operator()+0x78 [node_modules\@react-native-community\netinfo\windows\RNCNetInfoCPP\RNCNetInfo.cpp @ 147]
RNCNetInfoCPP!winrt::impl::delegate<winrt::Windows::Networking::Connectivity::NetworkStatusChangedEventHandler,<lambda_07af3bc3acbb5d7aa0533ab2f666cdc6> >::Invoke+0xc [node_modules\@react-native-community\netinfo\windows\RNCNetInfoCPP\Generated Files\winrt\Windows.Networking.Connectivity.h @ 791]