### PR TITLE
[Web] Checking `window` before accessing 

### DIFF
--- a/src/internal/nativeModule.web.ts
+++ b/src/internal/nativeModule.web.ts
@@ -8,22 +8,22 @@
  */
 
 import {
-  NetInfoNativeModule,
   DEVICE_CONNECTIVITY_EVENT,
+  NetInfoNativeModule,
   NetInfoNativeModuleState,
 } from './privateTypes';
 import {
+  NetInfoBluetoothState,
+  NetInfoCellularGeneration,
+  NetInfoCellularState,
+  NetInfoEthernetState,
+  NetInfoNoConnectionState,
+  NetInfoOtherState,
   NetInfoState,
   NetInfoStateType,
   NetInfoUnknownState,
-  NetInfoNoConnectionState,
-  NetInfoCellularState,
-  NetInfoBluetoothState,
-  NetInfoEthernetState,
   NetInfoWifiState,
   NetInfoWimaxState,
-  NetInfoOtherState,
-  NetInfoCellularGeneration,
 } from './types';
 
 // See https://wicg.github.io/netinfo/#dom-connectiontype
@@ -70,12 +70,14 @@ declare global {
     webkitConnection?: Connection;
   }
 }
+const isWindowPresent = typeof window !== 'undefined';
 
 // Check if window exists and if the browser supports the connection API
-const connection = 
-  window?.navigator.connection ||
-  window?.navigator.mozConnection ||
-  window?.navigator.webkitConnection;
+const connection = isWindowPresent
+  ? window.navigator.connection ||
+    window.navigator.mozConnection ||
+    window.navigator.webkitConnection
+  : undefined;
 
 // Map browser types to native types
 const typeMapping: Record<ConnectionType, NetInfoStateType> = {
@@ -249,8 +251,10 @@ const RNCNetInfo: NetInfoNativeModule = {
         if (connection) {
           connection.addEventListener('change', nativeHandler);
         } else {
-          window?.addEventListener('online', nativeHandler, false);
-          window?.addEventListener('offline', nativeHandler, false);
+          if (isWindowPresent) {
+            window.addEventListener('online', nativeHandler, false);
+            window.addEventListener('offline', nativeHandler, false);
+          }
         }
 
         // Remember handlers
@@ -272,8 +276,10 @@ const RNCNetInfo: NetInfoNativeModule = {
         if (connection) {
           connection.removeEventListener('change', nativeHandler);
         } else {
-          window?.removeEventListener('online', nativeHandler);
-          window?.removeEventListener('offline', nativeHandler);
+          if (isWindowPresent) {
+            window.removeEventListener('online', nativeHandler);
+            window.removeEventListener('offline', nativeHandler);
+          }
         }
 
         // Remove handlers

--- a/src/internal/nativeModule.web.ts
+++ b/src/internal/nativeModule.web.ts
@@ -249,10 +249,8 @@ const RNCNetInfo: NetInfoNativeModule = {
         if (connection) {
           connection.addEventListener('change', nativeHandler);
         } else {
-          if (hasWindow) {
-            window.addEventListener('online', nativeHandler, false);
-            window.addEventListener('offline', nativeHandler, false);
-          }
+          window?.addEventListener('online', nativeHandler, false);
+          window?.addEventListener('offline', nativeHandler, false);
         }
 
         // Remember handlers

--- a/src/internal/nativeModule.web.ts
+++ b/src/internal/nativeModule.web.ts
@@ -272,10 +272,8 @@ const RNCNetInfo: NetInfoNativeModule = {
         if (connection) {
           connection.removeEventListener('change', nativeHandler);
         } else {
-          if (hasWindow) {
-            window.removeEventListener('online', nativeHandler);
-            window.removeEventListener('offline', nativeHandler);
-          }
+          window?.removeEventListener('online', nativeHandler);
+          window?.removeEventListener('offline', nativeHandler);
         }
 
         // Remove handlers

--- a/src/internal/nativeModule.web.ts
+++ b/src/internal/nativeModule.web.ts
@@ -7,7 +7,7 @@
  * @format
  */
 
-import {
+ import {
   NetInfoNativeModule,
   DEVICE_CONNECTIVITY_EVENT,
   NetInfoNativeModuleState,
@@ -71,11 +71,14 @@ declare global {
   }
 }
 
-// Check if the browser supports the connection API
-const connection =
-  window.navigator.connection ||
-  window.navigator.mozConnection ||
-  window.navigator.webkitConnection;
+const isWindowPresent = typeof window !== 'undefined';
+
+// Check if window exists and if the browser supports the connection API
+const connection = isWindowPresent
+  ? window?.navigator.connection ||
+    window?.navigator.mozConnection ||
+    window?.navigator.webkitConnection
+  : undefined;
 
 // Map browser types to native types
 const typeMapping: Record<ConnectionType, NetInfoStateType> = {
@@ -249,8 +252,10 @@ const RNCNetInfo: NetInfoNativeModule = {
         if (connection) {
           connection.addEventListener('change', nativeHandler);
         } else {
-          window.addEventListener('online', nativeHandler, false);
-          window.addEventListener('offline', nativeHandler, false);
+          if (isWindowPresent) {
+            window.addEventListener('online', nativeHandler, false);
+            window.addEventListener('offline', nativeHandler, false);
+          }
         }
 
         // Remember handlers
@@ -272,8 +277,10 @@ const RNCNetInfo: NetInfoNativeModule = {
         if (connection) {
           connection.removeEventListener('change', nativeHandler);
         } else {
-          window.removeEventListener('online', nativeHandler);
-          window.removeEventListener('offline', nativeHandler);
+          if (isWindowPresent) {
+            window.removeEventListener('online', nativeHandler);
+            window.removeEventListener('offline', nativeHandler);
+          }
         }
 
         // Remove handlers

--- a/src/internal/nativeModule.web.ts
+++ b/src/internal/nativeModule.web.ts
@@ -71,8 +71,6 @@ declare global {
   }
 }
 
-const hasWindow = typeof window !== 'undefined';
-
 // Check if window exists and if the browser supports the connection API
 const connection = hasWindow
   ? window?.navigator.connection ||

--- a/src/internal/nativeModule.web.ts
+++ b/src/internal/nativeModule.web.ts
@@ -7,7 +7,7 @@
  * @format
  */
 
- import {
+import {
   NetInfoNativeModule,
   DEVICE_CONNECTIVITY_EVENT,
   NetInfoNativeModuleState,

--- a/src/internal/nativeModule.web.ts
+++ b/src/internal/nativeModule.web.ts
@@ -70,6 +70,8 @@ declare global {
     webkitConnection?: Connection;
   }
 }
+// Use a constant test of this form because in SSR on next.js, optional chaining is not sufficient,
+// but this test correctly detects that window is not available and allows for conditionals before access
 const isWindowPresent = typeof window !== 'undefined';
 
 // Check if window exists and if the browser supports the connection API

--- a/src/internal/nativeModule.web.ts
+++ b/src/internal/nativeModule.web.ts
@@ -71,10 +71,10 @@ declare global {
   }
 }
 
-const isWindowPresent = typeof window !== 'undefined';
+const hasWindow = typeof window !== 'undefined';
 
 // Check if window exists and if the browser supports the connection API
-const connection = isWindowPresent
+const connection = hasWindow
   ? window?.navigator.connection ||
     window?.navigator.mozConnection ||
     window?.navigator.webkitConnection
@@ -252,7 +252,7 @@ const RNCNetInfo: NetInfoNativeModule = {
         if (connection) {
           connection.addEventListener('change', nativeHandler);
         } else {
-          if (isWindowPresent) {
+          if (hasWindow) {
             window.addEventListener('online', nativeHandler, false);
             window.addEventListener('offline', nativeHandler, false);
           }
@@ -277,7 +277,7 @@ const RNCNetInfo: NetInfoNativeModule = {
         if (connection) {
           connection.removeEventListener('change', nativeHandler);
         } else {
-          if (isWindowPresent) {
+          if (hasWindow) {
             window.removeEventListener('online', nativeHandler);
             window.removeEventListener('offline', nativeHandler);
           }

--- a/src/internal/nativeModule.web.ts
+++ b/src/internal/nativeModule.web.ts
@@ -72,11 +72,10 @@ declare global {
 }
 
 // Check if window exists and if the browser supports the connection API
-const connection = hasWindow
-  ? window?.navigator.connection ||
-    window?.navigator.mozConnection ||
-    window?.navigator.webkitConnection
-  : undefined;
+const connection = 
+  window?.navigator.connection ||
+  window?.navigator.mozConnection ||
+  window?.navigator.webkitConnection;
 
 // Map browser types to native types
 const typeMapping: Record<ConnectionType, NetInfoStateType> = {


### PR DESCRIPTION

# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Solving https://github.com/react-native-netinfo/react-native-netinfo/issues/645

Add checks to web version of NetInfo to avoid trying to access properties of `undefined`. This scenario can occur when using this package with Server Side Rendering (SSR).

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

After adding these, I was able to build the Next.js app.
