### PR TITLE
fix(android): avoid crash on devices without wifi

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -141,7 +141,7 @@ public abstract class ConnectivityReceiver {
         WritableMap event = Arguments.createMap();
 
         // Add if WiFi is ON or OFF
-        if (NetInfoUtils.isAccessWifiStatePermissionGranted(getReactContext())) {
+        if (NetInfoUtils.isAccessWifiStatePermissionGranted(getReactContext()) && mWifiManager != null) {
             boolean isEnabled = mWifiManager.isWifiEnabled();
             event.putBoolean("isWifiEnabled", isEnabled);
         }
@@ -208,7 +208,7 @@ public abstract class ConnectivityReceiver {
                 }
                 break;
             case "wifi":
-                if (NetInfoUtils.isAccessWifiStatePermissionGranted(getReactContext())) {
+                if (NetInfoUtils.isAccessWifiStatePermissionGranted(getReactContext()) && mWifiManager != null) {
                     WifiInfo wifiInfo = mWifiManager.getConnectionInfo();
                     if (wifiInfo != null) {
                         // Get the SSID

--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -141,8 +141,11 @@ public abstract class ConnectivityReceiver {
         WritableMap event = Arguments.createMap();
 
         // Add if WiFi is ON or OFF
-        if (NetInfoUtils.isAccessWifiStatePermissionGranted(getReactContext()) && mWifiManager != null) {
-            boolean isEnabled = mWifiManager.isWifiEnabled();
+        if (NetInfoUtils.isAccessWifiStatePermissionGranted(getReactContext())) {
+            boolean isEnabled = false;
+            if (mWifiManager != null) {
+              isEnabled = mWifiManager.isWifiEnabled();
+            }
             event.putBoolean("isWifiEnabled", isEnabled);
         }
 


### PR DESCRIPTION
# Overview
I recently faced a crash on a device that does not have WiFi and not provide the WiFi system service.
```
java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.net.wifi.WifiManager.isWifiEnabled()' on a null object reference
        at com.reactnativecommunity.netinfo.ConnectivityReceiver.createConnectivityEventMap(ConnectivityReceiver.java:138)
        at com.reactnativecommunity.netinfo.ConnectivityReceiver.getCurrentState(ConnectivityReceiver.java:83)
        at com.reactnativecommunity.netinfo.NetInfoModule.getCurrentState(NetInfoModule.java:58)
.....
```
Only thing we use in our app is
`const { isConnected } = useNetInfo();`
So for us it doesn't really matter what kind of connection, if the device does not support WiFi but has some other connectivity it is fine.
This PR will add a null check for mWifiManager so it would not crash anymore.

# Test Plan
No test plan from my side, just followed the stacktrace that showed the crash and fixed the issue, also checked other usages of mWifiManager so it would not crash somewhere else.
