### PR TITLE
fix(web): verify `window` exists before attempting to access navigator

### DIFF
--- a/src/internal/nativeModule.web.ts
+++ b/src/internal/nativeModule.web.ts
@@ -107,7 +107,7 @@ const effectiveTypeMapping: Record<
 const getCurrentState = (
   _requestedInterface?: string,
 ): Pick<NetInfoState, Exclude<keyof NetInfoState, 'isInternetReachable'>> => {
-  const isConnected = navigator.onLine;
+  const isConnected = isWindowPresent ? navigator.onLine : false;
   const baseState = {
     isInternetReachable: null,
   };


### PR DESCRIPTION
Fix an issue causing an SSR exception if `getCurrentState` is called.

# Overview

As things currently stand, if for any reason you end up calling `getCurrentState` during SSR you end up getting an exception due to `navigator` being `undefined`.


# Test Plan

1. Call `getCurrentState` during SSR without this change. See you receive an exception.
2. Call `getCurrentState` during SSR _with_ this change. See you _do not_ receive an exception.