### PR TITLE
fix: do not crash on android 11

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
@@ -148,9 +148,13 @@ public class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
 
     private void asyncUpdateAndSend(int delay) {
         new Handler(Looper.getMainLooper()).postDelayed(() -> {
-            mCapabilities = getConnectivityManager().getNetworkCapabilities(mNetwork);
-            updateAndSend();
-
+            try {
+                mCapabilities = getConnectivityManager().getNetworkCapabilities(mNetwork);
+                updateAndSend();
+            } catch (SecurityException e) {
+                // Android 11 may throw a 'package does not belong' security exception here.
+                // We need to catch this to prevent app crash.
+            }
         }, delay);
     }
 

--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
@@ -107,8 +107,10 @@ public class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
                 try {
                     networkInfo = getConnectivityManager().getNetworkInfo(network);
                 } catch (SecurityException e) {
-                    // Android 11 may throw a 'package does not belong' security exception here.
-                    // We need to catch this to prevent app crash.
+                // Android 11 may throw a 'package does not belong' security exception here.
+                // Google fixed Android 14, 13 and 12 with the issue where Chaland Jean patched those versions.
+                // Android 11 is too old, so that's why we have to catch this exception here to be safe.
+               //  https://android.googlesource.com/platform/frameworks/base/+/249be21013e389837f5b2beb7d36890b25ecfaaf%5E%21/
                     networkInfo = null;
                 }
             }
@@ -153,6 +155,9 @@ public class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
                 updateAndSend();
             } catch (SecurityException e) {
                 // Android 11 may throw a 'package does not belong' security exception here.
+                // Google fixed Android 14, 13 and 12 with the issue where Chaland Jean patched those versions.
+                // Android 11 is too old, so that's why we have to catch this exception here to be safe.
+               //  https://android.googlesource.com/platform/frameworks/base/+/249be21013e389837f5b2beb7d36890b25ecfaaf%5E%21/
                 // We need to catch this to prevent app crash.
             }
         }, delay);

--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
@@ -104,7 +104,13 @@ public class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
             if (network != null) {
                 // This may return null per API docs, and is deprecated, but for older APIs (< VERSION_CODES.P)
                 // we need it to test for suspended internet
-                networkInfo = getConnectivityManager().getNetworkInfo(network);
+                try {
+                    networkInfo = getConnectivityManager().getNetworkInfo(network);
+                } catch (SecurityException e) {
+                    // Android 11 may throw a 'package does not belong' security exception here.
+                    // We need to catch this to prevent app crash.
+                    networkInfo = null;
+                }
             }
 
             // Check to see if the network is temporarily unavailable or if airplane mode is toggled on


### PR DESCRIPTION
# Overview
We are submitting this PR as part of the errors we are seeing in one of our hostapps in Microsoft on Android. Especially on Android 11, there seems to be a SecurityException thrown if the app is not bound yet while the Activity is created. Google has fixed this issue in vNext, Android 13 and Android 12. However, Android 11 still remains unpatched crashing around 500 times per week.

# Test Plan
For the test plan, it is a bit hard to repro due to the timing error. If you have a look at the fix by Chalard Jean at Google [here](https://android.googlesource.com/platform/frameworks/base/+/249be21013e389837f5b2beb7d36890b25ecfaaf%5E%21/), it involves several manual steps to get into this bad state for the ConnectivityManager.

# Issue link
https://github.com/react-native-netinfo/react-native-netinfo/issues/674
