### PR TITLE
feat(android): 🌟 add support for React Native 0.73

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,7 @@ def getExtOrIntegerDefault(name) {
 apply plugin: 'com.android.library'
 
 android {
+  namespace = "com.reactnativecommunity.netinfo"
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
 
   compileOptions {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,7 +1,12 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-	<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+<manifest
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	package="com.reactnativecommunity.netinfo">
+
+	<uses-permission
+		android:name="android.permission.ACCESS_NETWORK_STATE" />
+	<uses-permission
+		android:name="android.permission.ACCESS_WIFI_STATE" />
 
 </manifest>
   

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,12 +1,7 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-<manifest
-	xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.reactnativecommunity.netinfo">
-
-	<uses-permission
-		android:name="android.permission.ACCESS_NETWORK_STATE" />
-	<uses-permission
-		android:name="android.permission.ACCESS_WIFI_STATE" />
+	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+	<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
 </manifest>
   


### PR DESCRIPTION
# Overview
Starting from React Native v0.73 , all libraries will need to be updated with namespace due to the upgrade to AGP 8
https://github.com/react-native-community/discussions-and-proposals/issues/671

OS | Implemented
-- | --
iOS | ❌
Android | ✅

# Test Plan

I tested the changes on RN 0.71.11 and everything works!
