### PR TITLE
fix(android): making rn >= 73 support also compatible with rn <= 66

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,8 +29,13 @@ def getExtOrIntegerDefault(name) {
 apply plugin: 'com.android.library'
 
 android {
-  namespace = "com.reactnativecommunity.netinfo"
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
+
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  // Check AGP version for backward compatibility reasons
+  if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+    namespace = "com.reactnativecommunity.netinfo"
+  }
 
   compileOptions {
       sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
# Overview
Follow-up from https://github.com/react-native-netinfo/react-native-netinfo/pull/675. This ensure proper backwards-compability to older react-native and gradle versions.

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
