### PR TITLE
Fixed Typeerror for addvenetlistner added isWifiEnabled type in NetInfoUnknownState and NetInfoDisconnectedState

### DIFF
--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -48,6 +48,7 @@ interface NetInfoDisconnectedState<T extends NetInfoStateType> {
   isConnected: false;
   isInternetReachable: false;
   details: null;
+  isWifiEnabled?: boolean;
 }
 
 export interface NetInfoUnknownState {

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -55,6 +55,7 @@ export interface NetInfoUnknownState {
   isConnected: boolean | null;
   isInternetReachable: null;
   details: null;
+  isWifiEnabled?: boolean;
 }
 
 export type NetInfoNoConnectionState = NetInfoDisconnectedState<


### PR DESCRIPTION
# Overview
When using NetInfo.addEventListener was getting `isWifiEnabled` in data but was getting typeerror when using it. so add `isWifiEnabled` as `boolean` and optional type in NetInfoUnknownState and NetInfoDisconnectedState.

# Test Plan
1] Run Yarn test got all my the test cases passed.
2] Run yarn validate:typescript all test case passed without any error.