### PR TITLE
feat: add useNetInfoInstance - a non singleton-state hook to manage configs / events independently

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@
  * @format
  */
 
-import {useState, useEffect} from 'react';
+import {useState, useEffect, useCallback} from 'react';
 import {Platform} from 'react-native';
 import DEFAULT_CONFIGURATION from './internal/defaultConfiguration';
 import NativeInterface from './internal/nativeInterface';
@@ -26,7 +26,7 @@ const createState = (): State => {
 /**
  * Configures the library with the given configuration. Note that calling this will stop all
  * previously added listeners from being called again. It is best to call this right when your
- * application is started to avoid issues.
+ * application is started to avoid issues. The configuration sets up a global singleton instance.
  *
  * @param configuration The new configuration to set.
  */
@@ -50,6 +50,7 @@ export function configure(
 
 /**
  * Returns a `Promise` that resolves to a `NetInfoState` object.
+ * This function operates on the global singleton instance configured using `configure()`
  *
  * @param [requestedInterface] interface from which to obtain the information
  *
@@ -65,7 +66,7 @@ export function fetch(
 }
 
 /**
- * Force-refreshes the internal state of the NetInfo library.
+ * Force-refreshes the internal state of the global singleton managed by this library.
  *
  * @returns A Promise which contains the updated connection state.
  */
@@ -77,7 +78,7 @@ export function refresh(): Promise<Types.NetInfoState> {
 }
 
 /**
- * Subscribe to connection information. The callback is called with a parameter of type
+ * Subscribe to the global singleton's connection information. The callback is called with a parameter of type
  * [`NetInfoState`](README.md#netinfostate) whenever the connection state changes. Your listener
  * will be called with the latest information soon after you subscribe and then with any
  * subsequent changes afterwards. You should not assume that the listener is called in the same
@@ -101,7 +102,9 @@ export function addEventListener(
 }
 
 /**
- * A React Hook which updates when the connection state changes.
+ * A React Hook into this library's singleton which updates when the connection state changes.
+ *
+ * @param {Partial<Types.NetInfoConfiguration>} configuration - Configure the isolated network checker managed by this hook
  *
  * @returns The connection state.
  */
@@ -126,6 +129,51 @@ export function useNetInfo(
   return netInfo;
 }
 
+/**
+ * A React Hook which manages an isolated instance of the network info manager.
+ * This is not a hook into a singleton shared state. NetInfo.configure, NetInfo.addEventListener,
+ * NetInfo.fetch, NetInfo.refresh are performed on a global singleton and have no affect on this hook.
+ * @param {boolean} isPaused - Pause the internal network checks.
+ * @param {Partial<Types.NetInfoConfiguration>} configuration - Configure the isolated network checker managed by this hook
+ *
+ * @returns the netInfo state and a refresh function
+ */
+export function useNetInfoInstance(
+  isPaused = false,
+  configuration?: Partial<Types.NetInfoConfiguration>,
+) {
+  const [networkInfoManager, setNetworkInfoManager] = useState<State>();
+  const [netInfo, setNetInfo] = useState<Types.NetInfoState>({
+    type: Types.NetInfoStateType.unknown,
+    isConnected: null,
+    isInternetReachable: null,
+    details: null,
+  });
+
+  useEffect(() => {
+    if (isPaused) {
+      return;
+    }
+    const config = {
+      ...DEFAULT_CONFIGURATION,
+      ...configuration,
+    };
+    const state = new State(config);
+    setNetworkInfoManager(state);
+    state.add(setNetInfo);
+    return state.tearDown;
+  }, [isPaused, configuration]);
+
+  const refresh = useCallback(() => {
+    networkInfoManager && networkInfoManager._fetchCurrentState();
+  }, [networkInfoManager]);
+
+  return {
+    netInfo,
+    refresh,
+  };
+}
+
 export * from './internal/types';
 
 export default {
@@ -134,4 +182,5 @@ export default {
   refresh,
   addEventListener,
   useNetInfo,
+  useNetInfoInstance,
 };


### PR DESCRIPTION
# Overview
The objective here is to allow consumption of this library without the global singleton. I am currently experiencing a bug where this library is continuing to check the network status in the background and then when my app comes back into foreground and I retrieve the state from netinfo, it's saying there's no connection. This is because the netinfo singleton is running in the background and the network request eventually gets blocked by iOS. see issue [Issue #669](https://github.com/react-native-netinfo/react-native-netinfo/issues/669). It would be nice to pause checking the status when ever my app goes into the background. ie `useNetInfo({isPaused: true})`. It would nice for all network checking to stop if `useNetInfo` is unmounted.

This library manages a singleton which is beneficial in some cases but not ideal in others:
* When you'd like a different config for each useNetInfo. Why does passing a config to `useNetInfo` need to cause all other hooks to break? When ever `useNetInfo` is called with a config, the existing singleton is torn down and other hooks will stop receiving updates.
* You'd like to stop checking the network info when in background for example. ATM there's no way to stop the singleton from running once it has started. When `useNetInfo` is unmounted, the singleton continues to run, when `useNetInfo` is re-mounted, it just taps back into the currently running singleton.
* Shared state across `useNetInfo` hooks is not following reacts principle of [Hooks let you share stateful logic, not state itself](https://react.dev/learn/reusing-logic-with-custom-hooks#custom-hooks-let-you-share-stateful-logic-not-state-itself). The example in the docs even mention a hook called `useOnlineStatus`


This is a patch we've made in our own app to solve [Issue #669](https://github.com/react-native-netinfo/react-native-netinfo/issues/669). I'm sure there are others out there who'd be keen on this functionality too so I'm starting an initial PR to see if there is any appetite for this or something else that'll achieve similar outcomes.


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
