### PR TITLE
feat(android)!: specify export mode on BroadcastReceivers, requires compileSdk 33+

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,5 @@
-ReactNativeNetInfo_compileSdkVersion=29
+ReactNativeNetInfo_compileSdkVersion=33
 ReactNativeNetInfo_buildToolsVersion=29.0.3
 ReactNativeNetInfo_targetSdkVersion=27
 ReactNativeNetInfo_minSdkVersion=16
+android.useAndroidX=true

--- a/android/src/main/java/com/reactnativecommunity/netinfo/AmazonFireDeviceConnectivityPoller.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/AmazonFireDeviceConnectivityPoller.java
@@ -90,7 +90,7 @@ public class AmazonFireDeviceConnectivityPoller {
         IntentFilter filter = new IntentFilter();
         filter.addAction(ACTION_INTERNET_DOWN);
         filter.addAction(ACTION_INTERNET_UP);
-        context.registerReceiver(receiver, filter);
+        NetInfoUtils.compatRegisterReceiver(context, receiver, filter, false);
 
         receiver.registered = true;
     }

--- a/android/src/main/java/com/reactnativecommunity/netinfo/BroadcastReceiverConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/BroadcastReceiverConnectivityReceiver.java
@@ -39,7 +39,12 @@ public class BroadcastReceiverConnectivityReceiver extends ConnectivityReceiver 
     public void register() {
         IntentFilter filter = new IntentFilter();
         filter.addAction(CONNECTIVITY_ACTION);
-        getReactContext().registerReceiver(mConnectivityBroadcastReceiver, filter);
+        NetInfoUtils.compatRegisterReceiver(
+                getReactContext(),
+                mConnectivityBroadcastReceiver,
+                filter,
+                false
+        );
         mConnectivityBroadcastReceiver.setRegistered(true);
         updateAndSendConnectionType();
     }

--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoUtils.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoUtils.java
@@ -7,8 +7,12 @@
 package com.reactnativecommunity.netinfo;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
+import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.IntentFilter;
 import android.content.pm.PackageManager;
+import android.os.Build;
 
 import androidx.core.content.ContextCompat;
 
@@ -24,5 +28,23 @@ public class NetInfoUtils {
     public static boolean isAccessWifiStatePermissionGranted(Context context) {
         return ContextCompat.checkSelfPermission(context,
                 Manifest.permission.ACCESS_WIFI_STATE) == PackageManager.PERMISSION_GRANTED;
+    }
+
+
+    /**
+     * Starting with Android 14, apps and services that target Android 14 and use context-registered
+     * receivers are required to specify a flag to indicate whether or not the receiver should be
+     * exported to all other apps on the device: either RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED
+     * <a href="https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported"/>
+     */
+    @SuppressLint("UnspecifiedRegisterReceiverFlag")
+    public static void compatRegisterReceiver(
+            Context context, BroadcastReceiver receiver, IntentFilter filter, boolean exported) {
+        if (Build.VERSION.SDK_INT >= 34 && context.getApplicationInfo().targetSdkVersion >= 34) {
+            context.registerReceiver(
+                    receiver, filter, exported ? Context.RECEIVER_EXPORTED : Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            context.registerReceiver(receiver, filter);
+        }
     }
 }


### PR DESCRIPTION
This PR introduces Android targetSdk 34 (Android 14) support.

Without this PR, devices running Android 14 will crash if the app using this dependency is using `targetSdk=34`.

An alternative approach would be to directly include `androidx.core:core` as a dependency of this project and use `ContextCompat.registerReceiver` instead.

More information can be found in this issue: https://github.com/react-native-netinfo/react-native-netinfo/issues/681

This is the smallest change that I can make and have this work, I think. Locally, in order to get this to build on my machine, I did also need to upgrade the gradle wrapper to work with newer JDKs. But I don't think those changes are necessary for this PR. We'll see what CI says :P