### PR TITLE
Tizen support

### DIFF
--- a/src/internal/internetReachability.ts
+++ b/src/internal/internetReachability.ts
@@ -79,15 +79,19 @@ export default class InternetReachability {
 
     // Create promise that will reject after the request timeout has been reached
     let timeoutHandle: ReturnType<typeof setTimeout>;
-    const timeoutPromise = new Promise<Response>((): void => timeoutHandle = setTimeout(
-      (): void => controller.abort('timedout'),
-      this._configuration.reachabilityRequestTimeout,
-    ));
+    const timeoutPromise = new Promise<Response>((): void => {
+      timeoutHandle = setTimeout(
+        (): void => controller.abort('timedout'),
+        this._configuration.reachabilityRequestTimeout,
+      );
+    });
 
     // Create promise that makes it possible to cancel a pending request through a reject
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     let cancel: () => void = (): void => {};
-    const cancelPromise = new Promise<Response>((): void => cancel = (): void => controller.abort('canceled'));
+    const cancelPromise = new Promise<Response>((): void => {
+      cancel = (): void => controller.abort('canceled');
+    });
 
     const promise = Promise.race([
       responsePromise,

--- a/src/internal/nativeModule.web.ts
+++ b/src/internal/nativeModule.web.ts
@@ -75,7 +75,7 @@ declare global {
 const isWindowPresent = typeof window !== 'undefined';
 
 // Check if window exists and if the browser supports the connection API
-const connection = isWindowPresent
+const connection = (isWindowPresent && !window.tizen)
   ? window.navigator.connection ||
     window.navigator.mozConnection ||
     window.navigator.webkitConnection

--- a/src/internal/nativeModule.web.ts
+++ b/src/internal/nativeModule.web.ts
@@ -75,7 +75,7 @@ declare global {
 const isWindowPresent = typeof window !== 'undefined';
 
 // Check if window exists and if the browser supports the connection API
-const connection = (isWindowPresent && !window.tizen)
+const connection = (isWindowPresent && !window.tizen && !window.webOS)
   ? window.navigator.connection ||
     window.navigator.mozConnection ||
     window.navigator.webkitConnection


### PR DESCRIPTION
Web applications at Tizen use Chromium. And in the latest versions of Tizen seems being a support of Network Information API. I tasted react-native-netinfo at Tizen TV device and emulator. The event 'change' fired only at application start. If the connection is lost, the TV displays a native warning, but the event in Web application is not fired.

Firstly I found at Tizen docs guide to get information about network using [tizen API](https://docs.tizen.org/application/web/guides/device/system-information/). But then I came across an official guide for Web apps where 'online' / 'offline' are used to watch network connection changes.

So I decided to make an additional check for Tizen to solve this problem. Now web application fires events on connection changes at Tizen TV device and emulator.

The same solution works for WebOS