### PR TITLE
added support for Tizen and WebOS

### DIFF
--- a/src/internal/nativeModule.web.ts
+++ b/src/internal/nativeModule.web.ts
@@ -75,7 +75,7 @@ declare global {
 const isWindowPresent = typeof window !== 'undefined';
 
 // Check if window exists and if the browser supports the connection API
-const connection = isWindowPresent
+const connection = (isWindowPresent && !window.hasOwnProperty('tizen') && !window.hasOwnProperty('webOS'))
   ? window.navigator.connection ||
     window.navigator.mozConnection ||
     window.navigator.webkitConnection


### PR DESCRIPTION
Web applications at Tizen use Chromium. And in the latest versions of Tizen seems being a support of Network Information API. I tasted react-native-netinfo at Tizen TV device and emulator. The event 'change' fired only at application start. If the connection is lost, the TV displays a native warning, but the event in Web application is not fired.

Firstly I found at Tizen docs guide to get information about network using [tizen API](https://docs.tizen.org/application/web/guides/device/system-information/). But then I came across an official guide for Web apps where 'online' / 'offline' are used to watch network connection changes.

So I decided to make an additional check for Tizen to solve this problem. Now web application fires events on connection changes at Tizen TV device and emulator.

The same solution works for WebOS