### PR TITLE
feat: add visionOS support

### DIFF
--- a/ios/RNCConnectionState.m
+++ b/ios/RNCConnectionState.m
@@ -6,11 +6,11 @@
  */
 
 #import "RNCConnectionState.h"
-#if !TARGET_OS_TV && !TARGET_OS_MACCATALYST
+#if !TARGET_OS_TV && !TARGET_OS_MACCATALYST && !TARGET_OS_VISION
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #endif
 
-#if TARGET_OS_TV || TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#if TARGET_OS_TV || TARGET_OS_OSX || TARGET_OS_MACCATALYST || TARGET_OS_VISION
 #include <ifaddrs.h>
 #endif
 
@@ -41,7 +41,7 @@
             (flags & kSCNetworkReachabilityFlagsConnectionRequired) != 0) {
             _type = RNCConnectionTypeNone;
         }
-#if !TARGET_OS_TV && !TARGET_OS_OSX && !TARGET_OS_MACCATALYST
+#if !TARGET_OS_TV && !TARGET_OS_OSX && !TARGET_OS_MACCATALYST && !TARGET_OS_VISION
         else if ((flags & kSCNetworkReachabilityFlagsIsWWAN) != 0) {
             _type = RNCConnectionTypeCellular;
             _expensive = true;
@@ -73,7 +73,7 @@
 #endif
         else {
             _type = RNCConnectionTypeWifi;
-#if TARGET_OS_TV || TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#if TARGET_OS_TV || TARGET_OS_OSX || TARGET_OS_MACCATALYST || TARGET_OS_VISION
             struct ifaddrs *interfaces = NULL;
             struct ifaddrs *temp_addr = NULL;
             int success = 0;

--- a/ios/RNCNetInfo.m
+++ b/ios/RNCNetInfo.m
@@ -11,7 +11,7 @@
 #include <ifaddrs.h>
 #include <arpa/inet.h>
 
-#if !TARGET_OS_TV && !TARGET_OS_MACCATALYST
+#if !TARGET_OS_TV && !TARGET_OS_MACCATALYST && !TARGET_OS_VISION
 #import <CoreTelephony/CTCarrier.h>
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #endif
@@ -130,7 +130,7 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)config)
   } else if ([requestedInterface isEqualToString: RNCConnectionTypeWifi] || [requestedInterface isEqualToString: RNCConnectionTypeEthernet]) {
     details[@"ipAddress"] = [self ipAddress] ?: NSNull.null;
     details[@"subnet"] = [self subnet] ?: NSNull.null;
-    #if !TARGET_OS_TV && !TARGET_OS_OSX && !TARGET_OS_MACCATALYST
+    #if !TARGET_OS_TV && !TARGET_OS_OSX && !TARGET_OS_MACCATALYST && !TARGET_OS_VISION
       /*
         Without one of the conditions needed to use CNCopyCurrentNetworkInfo, it will leak memory.
         Clients should only set the shouldFetchWiFiSSID to true after ensuring requirements are met to get (B)SSID.
@@ -146,7 +146,7 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)config)
 
 - (NSString *)carrier
 {
-#if (TARGET_OS_TV || TARGET_OS_OSX || TARGET_OS_MACCATALYST)
+#if (TARGET_OS_TV || TARGET_OS_OSX || TARGET_OS_MACCATALYST || TARGET_OS_VISION)
   return nil;
 #else
   CTTelephonyNetworkInfo *netinfo = [[CTTelephonyNetworkInfo alloc] init];

--- a/react-native-netinfo.podspec
+++ b/react-native-netinfo.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platforms    = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" }
+  s.platforms    = { :ios => "9.0", :tvos => "9.2", :osx => "10.14", :visionos => "1.0" }
 
   s.source       = { :git => "https://github.com/react-native-community/react-native-netinfo.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

This PR adds support for [React Native visionOS](https://github.com/callstack/react-native-visionos), the new out-of-tree platform.

VisionOS also does not support the `CoreTelephony` API, so it's just a matter of adding extra checks for `TARGET_OS_VISION` where we already have checking for other platforms such as `TARGET_OS_TV`, `TARGET_OS_OSX` and `TARGET_OS_MACCATALYST`.

![simulator_screenshot_755C607B-9600-445C-8821-74A06E0A0BE0](https://github.com/react-native-netinfo/react-native-netinfo/assets/26878038/1e58aa1b-bb0b-48a6-8fac-16a5ab0ff011)

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

- `yarn test`: all tests still pass
- `yarn start:ios` and `yarn start:macos`: all platforms still build with no issues.

<details>
<summary>iOS</summary>

![simulator_screenshot_1B74206F-5A3D-439B-931A-BCF348A509A4](https://github.com/react-native-netinfo/react-native-netinfo/assets/26878038/e671510e-3f6b-4515-8bb9-cdc964f7193b)

</details>


<details>
<summary>macOS</summary>

![CleanShot 2024-02-14 at 17 03 42](https://github.com/react-native-netinfo/react-native-netinfo/assets/26878038/1515d2ed-282c-4fb6-b17c-b07d6a7efe1a)

</details>