### PR TITLE
fix: update nativeInterface default export to support bridgeless mode

### DIFF
--- a/src/internal/nativeInterface.ts
+++ b/src/internal/nativeInterface.ts
@@ -28,8 +28,7 @@ If none of these fix the issue, please open an issue on the Github repository: h
  * JavaScript code and the tests
  */
 let nativeEventEmitter: NativeEventEmitter | null = null;
-export default {
-  ...RNCNetInfo,
+const nativeInterface = Object.assign(RNCNetInfo, {
   get eventEmitter(): NativeEventEmitter {
     if (!nativeEventEmitter) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -40,4 +39,5 @@ export default {
     /// @ts-ignore
     return nativeEventEmitter;
   },
-};
+});
+export default nativeInterface;


### PR DESCRIPTION
# Overview

When trying to use `react-native-netinfo` with the new architecture and bridgeless mode on (react-native version 0.74.0-nightly-20240123-cbd818dad), the user is faced with an unhandled promise rejection 

<img width="476" alt="image" src="https://github.com/react-native-netinfo/react-native-netinfo/assets/11707729/b6038511-68da-4bfa-a354-0364e497cc20">



----
This error happens because of the following code inside nativeInterface.ts

https://github.com/react-native-netinfo/react-native-netinfo/blob/94c5398a3debad44190ba1f71f766401b424ebfe/src/internal/nativeInterface.ts#L31-L38

Currently we cannot use the spread operator directly on the object returned from React Native's NativeModules, given that the module object is a host object. So to fix that we should use `Object.assign` instead or directly use `NativeModules.RNCNetInfo`

After this change everything works as expected and the compatibility layer allows `react-native-netinfo` to be used with bridgeless mode on


# Test Plan

Tested running on Android and iOS with: 
- new arch, bridgeless off
- new arch, bridgeless on
- old arch
