### PR TITLE
fix react-native 0.74 Use invalidate method instead onCatalystInstanceDestroy

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoModule.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoModule.java
@@ -42,7 +42,7 @@ public class NetInfoModule extends ReactContextBaseJavaModule implements AmazonF
     }
 
     @Override
-    public void onCatalystInstanceDestroy() {
+    public void invalidate() {
         mAmazonConnectivityChecker.unregister();
         mConnectivityReceiver.unregister();
         mConnectivityReceiver.hasListener = false;


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
