### PR TITLE
fix: ensure one reachability check in-flight at once / proper useEffect listener cleanup

### DIFF
--- a/example/ConnectionInfoRefresh.tsx
+++ b/example/ConnectionInfoRefresh.tsx
@@ -34,12 +34,21 @@ export default class ConnectionInfoCurrent extends React.Component<
     });
   };
 
+  _triggerMultipleRefreshes = (): void => {
+    // Trigger multiple refreshes in quick succession
+    this._refreshState();
+    this._refreshState();
+    this._refreshState();
+    this._refreshState();
+  };
+
   render() {
     return (
       <View>
-        <TouchableOpacity onPress={this._refreshState}>
-          <Text style={{color: 'black'}}>{this.state.connectionInfo}</Text>
+        <TouchableOpacity onPress={this._triggerMultipleRefreshes}>
+          <Text>Tap to trigger multiple refreshes</Text>
         </TouchableOpacity>
+        <Text style={{color: 'black'}}>{this.state.connectionInfo}</Text>
       </View>
     );
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,9 @@ const createState = (): State => {
   return new State(_configuration);
 };
 
+// Track ongoing requests
+let isRequestInProgress = false;
+
 /**
  * Configures the library with the given configuration. Note that calling this will stop all
  * previously added listeners from being called again. It is best to call this right when your
@@ -74,7 +77,16 @@ export function refresh(): Promise<Types.NetInfoState> {
   if (!_state) {
     _state = createState();
   }
-  return _state._fetchCurrentState();
+
+  if (isRequestInProgress) {
+    return _state.latest(); // Return the latest state if a request is already in progress
+  }
+
+  isRequestInProgress = true;
+
+  return _state._fetchCurrentState().finally(() => {
+    isRequestInProgress = false;
+  });
 }
 
 /**
@@ -123,7 +135,8 @@ export function useNetInfo(
   });
 
   useEffect((): (() => void) => {
-    return addEventListener(setNetInfo);
+    const unsubscribe = addEventListener(setNetInfo);
+    return () => unsubscribe();
   }, []);
 
   return netInfo;
@@ -165,7 +178,12 @@ export function useNetInfoInstance(
   }, [isPaused, configuration]);
 
   const refresh = useCallback(() => {
-    networkInfoManager && networkInfoManager._fetchCurrentState();
+    if (networkInfoManager && !isRequestInProgress) {
+      isRequestInProgress = true;
+      networkInfoManager._fetchCurrentState().finally(() => {
+        isRequestInProgress = false;
+      });
+    }
   }, [networkInfoManager]);
 
   return {


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
We use react-native-netinfo in our app and encountered an issue with the library sending multiple reachability requests in parallel. 

This PR adds isRequestInProgress to track whether a reachability request is currently in progress, preventing multiple parallel requests.

Additionally, it implements proper cleanup of listeners in useEffect to prevent multiple listeners from being active simultaneously.


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

1. Run the example app
2. Tap the "Tap to trigger multiple refreshes" button
3. Observe that subsequent refresh calls were prevented due to an ongoing requests


https://github.com/react-native-netinfo/react-native-netinfo/assets/19835085/2b549688-783b-4914-8fb9-624a99653d9e

