### PR TITLE
build: Use node resolver to find react native package directory

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,7 +54,16 @@ android {
 repositories {
   maven {
     // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-    url "$rootDir/../node_modules/react-native/android"
+
+    // Use node resolver to locate react-native package
+    def reactNativePackage = file(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim())
+    if (reactNativePackage.exists()) {
+      url "$reactNativePackage.parentFile/android"
+    }
+    // Fallback to react-native package colocated in node_modules
+    else {
+      url "$rootDir/../node_modules/react-native/android"
+    }
   }
   google()
   mavenLocal()


### PR DESCRIPTION
# Overview
Monorepos are configured and structured on what works best for the project. Since this can vary from project to project, having a dynamic way to find dependencies will make this work for more projects. Currently, the repo only supports certain configurations of Monorepo structures. This PR adopts a similar approach as Expo to locate the react native package within the project. [Expo usage for reference]( https://github.com/expo/expo/blob/9821f2f8c8927d930a15041f22cd55e28f443274/packages/expo-modules-core/README.md?plain=1#L65)

This PR also falls back to the original functionality if the package cannot be resolved by node.


# Test Plan
1. `yarn`
2. `yarn start`
3. `yarn start:android`
4. Put in a `println` statement to see what `$reactNativePackage.parentFile` is on the next build to see it working.
5. `yarn start:android`