### PR TITLE
fix(android): add invalidate method for rn74+, onCatalystInstanceDestroy delegates

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoModule.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoModule.java
@@ -41,8 +41,17 @@ public class NetInfoModule extends ReactContextBaseJavaModule implements AmazonF
         mAmazonConnectivityChecker.register();
     }
 
-    @Override
+    // the upstream method was removed in react-native 0.74
+    // this stub remains for backwards compatibility so that react-native < 0.74
+    // (which will still call onCatalystInstanceDestroy) will continue to function
     public void onCatalystInstanceDestroy() {
+        invalidate();
+    }
+
+    // This should have an `@Override` tag, but the method does not exist until
+    // react-native >= 0.74, which would cause linting errors across versions
+    // once minimum supported react-native here is 0.74+, add the tag
+    public void invalidate() {
         mAmazonConnectivityChecker.unregister();
         mConnectivityReceiver.unregister();
         mConnectivityReceiver.hasListener = false;


### PR DESCRIPTION


leaving the old method here so that old react-native versions will still work correctly, but it just delegates to the new method, which has the old implementation

should have no effect on anyone except for fixing compile issues

Supercedes / Closes #723