### PR TITLE
fix: #719 Use global delegate fixing Android TooManyRequestsException

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiverDelegate.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiverDelegate.java
@@ -1,0 +1,171 @@
+package com.reactnativecommunity.netinfo;
+
+import android.os.Build;
+
+import com.facebook.common.internal.Supplier;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+
+import java.lang.ref.WeakReference;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class ConnectivityReceiverDelegate implements IConnectivityReceiverDelegate {
+
+  @Nullable
+  private ConnectivityReceiver mConnectivityReceiver = null;
+
+  private final CopyOnWriteArraySet<WeakReactApplicationContext> mListeners;
+
+  private ConnectivityReceiverDelegate() {
+    mListeners = new CopyOnWriteArraySet<>();
+  }
+
+  public static ConnectivityReceiverDelegate getInstance() {
+    return InstanceHolder.INSTANCE;
+  }
+
+  public void addReactListener(@Nonnull ReactApplicationContext context) {
+    createNetworkConnectivityReceiverIfNeed(context).mNumberOfReactListeners.incrementAndGet();
+  }
+
+  public void removeReactListener(@Nonnull ReactApplicationContext context, int count) {
+    createNetworkConnectivityReceiverIfNeed(context).mNumberOfReactListeners.addAndGet(-count);
+  }
+
+  public synchronized ConnectivityReceiver createNetworkConnectivityReceiverIfNeed(@Nonnull ReactApplicationContext context) {
+    if (mConnectivityReceiver == null) {
+      // Create the connectivity receiver based on the API level we are running on
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        mConnectivityReceiver = new NetworkCallbackConnectivityReceiver(context);
+      } else {
+        mConnectivityReceiver = new BroadcastReceiverConnectivityReceiver(context);
+      }
+      mConnectivityReceiver.setReceiverDelegate(this);
+    }
+    return mConnectivityReceiver;
+  }
+
+  @Override
+  public synchronized void sendConnectivityChangedEvent(@Nonnull String eventName,
+                                                        @Nonnull Supplier<ReadableMap> data) {
+    if (mListeners.isEmpty()) {
+      return;
+    }
+
+    for (WeakReactApplicationContext weak : mListeners) {
+      final ReactApplicationContext context = weak.mContext.get();
+      if (context != null && context.hasActiveReactInstance()) {
+        // the event data to emit must be from supplier get method,
+        // otherwise there may be some map consumed exceptions from React Native.
+        context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(eventName,
+            data.get());
+      }
+    }
+  }
+
+  @Override
+  public synchronized void register(@Nonnull ReactApplicationContext context) {
+    if (mListeners.isEmpty()) {
+      // register to system service
+      createNetworkConnectivityReceiverIfNeed(context).register();
+    }
+    mListeners.add(new WeakReactApplicationContext(context));
+  }
+
+  @Override
+  public synchronized void unregister(@Nonnull ReactApplicationContext context) {
+    mListeners.remove(new WeakReactApplicationContext(context));
+
+    clearListenersIfShould();
+
+    if (mListeners.isEmpty()) {
+      destroyNetworkConnectivityReceiverIfNeed();
+    }
+  }
+
+  private void destroyNetworkConnectivityReceiverIfNeed() {
+    if (mConnectivityReceiver != null) {
+      mConnectivityReceiver.unregister();
+      mConnectivityReceiver = null;
+    }
+  }
+
+  /**
+   * clear the listeners set if no context alive.
+   */
+  private void clearListenersIfShould() {
+    boolean should = true;
+    for (WeakReactApplicationContext weak : mListeners) {
+      if (weak.mContext.get() != null) {
+        should = false;
+        break;
+      }
+    }
+    if (should) {
+      mListeners.clear();
+    }
+  }
+
+  @Override
+  public synchronized void getCurrentState(@javax.annotation.Nullable String requestedInterface,
+                                           @Nonnull Promise promise) {
+    if (mConnectivityReceiver == null) {
+      promise.reject("-999", "not register network info listener");
+      return;
+    }
+
+    mConnectivityReceiver.getCurrentState(requestedInterface, promise);
+  }
+
+  @Override
+  public synchronized void setIsInternetReachableOverride(boolean isInternetReachableOverride) {
+    if (mConnectivityReceiver == null) {
+      return;
+    }
+
+    mConnectivityReceiver.setIsInternetReachableOverride(isInternetReachableOverride);
+  }
+
+  private static class InstanceHolder {
+    private static final ConnectivityReceiverDelegate INSTANCE = new ConnectivityReceiverDelegate();
+  }
+
+  private static class WeakReactApplicationContext {
+    private final WeakReference<ReactApplicationContext> mContext;
+
+    public WeakReactApplicationContext(@Nonnull ReactApplicationContext context) {
+      mContext = new WeakReference<>(context);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+      if (this == obj) {
+        return true;
+      }
+
+      if (obj == null || getClass() != obj.getClass()) {
+        return false;
+      }
+
+      WeakReactApplicationContext that = (WeakReactApplicationContext) obj;
+      ReactApplicationContext context = mContext.get();
+      ReactApplicationContext thatContext = that.mContext.get();
+      if (context != null) {
+        return context.equals(thatContext);
+      }
+
+      return thatContext == null;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(mContext.get());
+    }
+  }
+}

--- a/android/src/main/java/com/reactnativecommunity/netinfo/IConnectivityReceiverDelegate.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/IConnectivityReceiverDelegate.java
@@ -1,0 +1,22 @@
+package com.reactnativecommunity.netinfo;
+
+import com.facebook.common.internal.Supplier;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableMap;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public interface IConnectivityReceiverDelegate {
+
+  void sendConnectivityChangedEvent(@Nonnull String eventName, @Nonnull Supplier<ReadableMap> data);
+
+  void register(@Nonnull ReactApplicationContext context);
+
+  void unregister(@Nonnull ReactApplicationContext context);
+
+  void getCurrentState(@Nullable final String requestedInterface, @Nonnull final Promise promise);
+
+  void setIsInternetReachableOverride(boolean isInternetReachableOverride);
+}


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

The reason of this issue is [system limits](https://cs.android.com/android/platform/superproject/main/+/main:packages/modules/Connectivity/framework/src/android/net/ConnectivityManager.java;l=4944#:~:text=4943-,4944,-4945) and [counter](https://cs.android.com/android/platform/superproject/main/+/main:packages/modules/Connectivity/service/src/com/android/server/ConnectivityService.java;l=8173;drc=8c326b9054263acb63ee0137a013a1bf584cab53;bpv=0;bpt=1#:~:text=8172-,8173,-8174)

![image](https://github.com/user-attachments/assets/5606b4c0-4972-4f66-ae8c-6ed23c051a6b).

And the cause of the issue may be that App may have created multiple RN instance and they all register network callbacks to system, mixed with that some native business also registering some callbacks, then resulted in the number of callbacks in the app goes up to the limits.

I've fixed this issue in our prt environment by registering only one network callbacks and sharing the callback from system to the other RN instances.



# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

I have fixed the issue in our prt environment.
