### PR TITLE
fix: enable `configuration-cache`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,26 +52,10 @@ android {
 }
 
 repositories {
-  maven {
-    // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-
-    // Use node resolver to locate react-native package
-    def reactNativePackage = file(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim())
-    if (reactNativePackage.exists()) {
-      url "$reactNativePackage.parentFile/android"
-    }
-    // Fallback to react-native package colocated in node_modules
-    else {
-      url "$rootDir/../node_modules/react-native/android"
-    }
-  }
-  google()
-  mavenLocal()
   mavenCentral()
+  google()
 }
 
 dependencies {
-  //noinspection GradleDynamicVersion
-  implementation 'com.facebook.react:react-native:+'
-
+  implementation 'com.facebook.react:react-native'
 }


### PR DESCRIPTION
# Overview

Fixes:
```
Starting an external process 'node --print require.resolve('react-native/package.json')' during configuration time is unsupported
``` 
when `configuration-cache` is enabled.
Adding the local repository is redundant, so I've removed it. I've ensured that it's aligned with the newest template for the React Native library.

# Test Plan

- build project with `configuration-cache` ✅ 