### PR TITLE
Fix nullable type for requestedInterface parameter

### DIFF
--- a/ios/RNCNetInfo.mm
+++ b/ios/RNCNetInfo.mm
@@ -99,7 +99,7 @@ RCT_EXPORT_MODULE()
 
 #pragma mark - Public API
 
-RCT_EXPORT_METHOD(getCurrentState:(nullable NSString *)requestedInterface resolve:(RCTPromiseResolveBlock)resolve
+RCT_EXPORT_METHOD(getCurrentState:(NSString *)requestedInterface resolve:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject)
 {
   RNCConnectionState *state = [self.connectionStateWatcher currentState];


### PR DESCRIPTION
https://github.com/react-native-netinfo/react-native-netinfo/issues/787

The generated spec file (from codegen) defines the method signature inside [NS_ASSUME_NONNULL_BEGIN/END] block, which means [requestedInterface] is implicitly nonnull. But the implementation in [RNCNetInfo.mm] uses [nullable NSString *] which conflicts with the nonnull from the spec.