### PR TITLE
fix: use more robust node resolver for monorepos

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,11 +37,15 @@ def resolveReactNativeDirectory() {
     return file(reactNativeLocation)
   }
 
-  // monorepo workaround
-  // react-native can be hoisted or in project's own node_modules
-  def reactNativeFromProjectNodeModules = file("${rootProject.projectDir}/../node_modules/react-native")
-  if (reactNativeFromProjectNodeModules.exists()) {
-    return reactNativeFromProjectNodeModules
+  // Fallback to node resolver for custom directory structures like monorepos.
+  def reactNativePackage = file(
+          providers.exec {
+              workingDir(rootDir)
+              commandLine("node", "--print", "require.resolve('react-native/package.json')")
+          }.standardOutput.asText.get().trim()
+  )
+  if (reactNativePackage.exists()) {
+    return reactNativePackage.parentFile
   }
 
   def reactNativeFromNodeModulesWithRNCNetInfo = file("${projectDir}/../../react-native")


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Update Android build.gradle to resolve the React Native directory via Node’s module resolver, providing a more reliable fallback for monorepos or nonstandard directory layouts where react-native may be hoisted. This is the same exact workaround used in [`react-native-reanimated`](https://github.com/software-mansion/react-native-reanimated/blob/aec6dc8a8567897a965aacfb47e1624d1c916e15/packages/react-native-reanimated/android/build.gradle#L34C5-L41C6).

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Able to run `yarn start:android`. Verified that gradle sync passes in my monorepo project.