### PR TITLE
chore: document that native module load style is used for react-native 0.77+

### DIFF
--- a/src/internal/nativeModule.ts
+++ b/src/internal/nativeModule.ts
@@ -10,14 +10,15 @@
 import {NativeModules} from 'react-native';
 import {NetInfoNativeModule} from './privateTypes';
 
-// React Native sets `__turboModuleProxy` on global when TurboModules are enabled.
-// Currently, this is the recommended way to detect TurboModules.
-// https://reactnative.dev/docs/the-new-architecture/backward-compatibility-turbomodules#unify-the-javascript-specs
+// React Native sets `__turboModuleProxy` on global when TurboModules are enabled for
+// react-native versions < 0.77. After that, they unified access and no longer set
+// `__turboModuleProxy` so it fails as a test. However, our native module name
+// stays the same, so we can just blindly load using unified loading in RN >= 77
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-const isTurboModuleEnabled = global.__turboModuleProxy != null;
+const legacyTurboModuleAccess = global.__turboModuleProxy != null;
 
-const RNCNetInfo: NetInfoNativeModule = isTurboModuleEnabled
+const RNCNetInfo: NetInfoNativeModule = legacyTurboModuleAccess
   ? // eslint-disable-next-line @typescript-eslint/no-var-requires
     require('./NativeRNCNetInfo').default
   : NativeModules.RNCNetInfo;


### PR DESCRIPTION
# Overview

the "require(<modulename>).default" style of TurboModule load is no longer recommended or needed, but the `__turboModuleProxy` global variable went away as part of making the new native load style unnecessary, so the conditional and fallback module load style is coincidentally still perfect

So, just document that we're actually testing for *legacy* turbomodule load style being needed, and that with RN77+ just blindly loading the module works because loading is unified

# Test Plan

The example app continued to run perfectly locally - and it is just a variable name change + comments - should be fine ?