### PR TITLE
fix(ios): new wifi config API usage requires NetworkExtension framework

### DIFF
--- a/react-native-netinfo.podspec
+++ b/react-native-netinfo.podspec
@@ -12,10 +12,12 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platforms    = { :ios => "9.0", :tvos => "9.2", :osx => "10.14", :visionos => "1.0" }
+  s.platforms    = { :ios => "14.0", :tvos => "14.0", :osx => "14.0", :visionos => "1.0" }
 
   s.source       = { :git => "https://github.com/react-native-community/react-native-netinfo.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m,mm,swift}"
+  s.frameworks = 'NetworkExtension'
+
 
   if is_new_arch_enabled
     install_modules_dependencies(s)


### PR DESCRIPTION
# Overview

Net API used for hotspot info requires the NetworkExtension framework but our podspec didn't express that

Thanks to @dallas62 for the report

- Fixes #792 

# Test Plan

fresh `@react-native-community/cli init netinfotest` test project with netinfo in there and I fiddled with the podspec in node_modules until it was building (after reproducing the error at first...), and I'm committing the result here
