### PR TITLE
fix(android): resolve react-native via filesystem walk for Configuration Cache compat

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,5 @@
+import java.nio.file.Paths
+
 buildscript {
   // The Android Gradle plugin is only required when opening the android folder stand-alone.
   // This avoids unnecessary downloads and potential conflicts when the library is included as a
@@ -31,21 +33,29 @@ def isNewArchitectureEnabled() {
   return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
 }
 
+static def findNodeModulePath(baseDir, packageName) {
+  def basePath = baseDir.toPath().normalize()
+  // Node's module resolution algorithm searches up to the root directory,
+  // after which the base path will be null
+  while (basePath) {
+    def candidatePath = Paths.get(basePath.toString(), "node_modules", packageName)
+    if (candidatePath.toFile().exists()) {
+      return candidatePath.toString()
+    }
+    basePath = basePath.getParent()
+  }
+  return null
+}
+
 def resolveReactNativeDirectory() {
   def reactNativeLocation = getExtOrInitialValue("REACT_NATIVE_NODE_MODULES_DIR", null)
   if (reactNativeLocation != null) {
     return file(reactNativeLocation)
   }
 
-  // Fallback to node resolver for custom directory structures like monorepos.
-  def reactNativePackage = file(
-          providers.exec {
-              workingDir(rootDir)
-              commandLine("node", "--print", "require.resolve('react-native/package.json')")
-          }.standardOutput.asText.get().trim()
-  )
-  if (reactNativePackage.exists()) {
-    return reactNativePackage.parentFile
+  def reactNativePackagePath = findNodeModulePath(projectDir, "react-native")
+  if (reactNativePackagePath != null) {
+    return file(reactNativePackagePath)
   }
 
   def reactNativeFromNodeModulesWithRNCNetInfo = file("${projectDir}/../../react-native")


### PR DESCRIPTION
# Overview

`resolveReactNativeDirectory()` uses `providers.exec` to spawn a `node` process at Gradle configuration time. Calling `.get()` eagerly forces evaluation, breaking Configuration Cache (RN 0.79+).

This replaces the node process with a `findNodeModulePath` helper that walks up the directory tree looking for `react-native` in `node_modules`, using pure file I/O. Existing fallbacks (`REACT_NATIVE_NODE_MODULES_DIR` override and the legacy `../../react-native` relative path) are preserved.

### Prior art

Same approach used by:

- **facebook/react-native**: [`ReactAndroid/build.gradle.kts#L485`](https://github.com/facebook/react-native/blob/62d89cb5ac8e959af6827f8f74f0ecf78cca8858/packages/react-native/ReactAndroid/build.gradle.kts#L485)
- **react-native-webview**: [`android/build.gradle#L21-L33`](https://github.com/react-native-webview/react-native-webview/blob/6960a1903c3c32e1e77be11e6370f1c384ed7ee4/android/build.gradle#L21-L33)

### Related

- #762 - addresses the `repositories` block `.execute()` call (separate concern)
- #789 - introduced `providers.exec` which is still not config-cache safe due to eager `.get()`
- https://github.com/react-native-netinfo/react-native-netinfo/pull/762#issuecomment-3942425949

# Test Plan

- [x] All existing unit tests pass
- [x] Builds on my own monorepo project